### PR TITLE
Define entry point for training the detector

### DIFF
--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import lightning
 import torch
-import typer
 import yaml  # type: ignore
 from lightning.pytorch.loggers import MLFlowLogger
 
@@ -199,7 +198,7 @@ def app_wrapper():
     torch.set_float32_matmul_precision("medium")
 
     train_args = train_parse_args(sys.argv[1:])
-    typer.run(main(train_args))
+    main(train_args)
 
 
 if __name__ == "__main__":

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import lightning
 import torch
+import typer
 import yaml  # type: ignore
 from lightning.pytorch.loggers import MLFlowLogger
 
@@ -194,8 +195,12 @@ def train_parse_args(args):
     return parser.parse_args(args)
 
 
-if __name__ == "__main__":
+def app_wrapper():
     torch.set_float32_matmul_precision("medium")
 
     train_args = train_parse_args(sys.argv[1:])
-    main(train_args)
+    typer.run(main(train_args))
+
+
+if __name__ == "__main__":
+    app_wrapper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
 [project.scripts]
 extract-frames = "crabs.bboxes_labelling.extract_frames_to_label_w_sleap:app_wrapper"
 combine-annotations = "crabs.bboxes_labelling.combine_and_format_annotations:app_wrapper"
+train-detector = "crabs.detection_tracking.train_model:app_wrapper"
 # verify-videos-and-extract-samples
 # extract-additional-channels
 # train-models

--- a/tests/test_unit/test_entry_points.py
+++ b/tests/test_unit/test_entry_points.py
@@ -5,10 +5,7 @@ import pytest
 
 @pytest.mark.parametrize(
     "cli_command",
-    [
-        "extract-frames",
-        "combine-annotations",
-    ],
+    ["extract-frames", "combine-annotations", "train-detector"],
 )
 def test_smoke(cli_command: str) -> None:
     status = os.system(f"{cli_command} --help")


### PR DESCRIPTION
Allows for a more succinct syntax independent of the cwd:
```
train-detector --dataset-dirs /path/to/dataset
```

vs before, we needed to run the following from the repo root:
```
python crabs/detection_tracking/train_model.py --dataset-dirs /path/to/dataset
```
