### PR TITLE
Recover stage argument in setup for datamodule

### DIFF
--- a/crabs/detection_tracking/datamodules.py
+++ b/crabs/detection_tracking/datamodules.py
@@ -152,7 +152,7 @@ class CrabsDataModule(LightningDataModule):
         """
         pass
 
-    def setup(self, stage: str):  # type: ignore
+    def setup(self, stage: str):
         """Setup the data for training, testing and validation.
 
         Define the transforms for each split of the data and compute them.

--- a/crabs/detection_tracking/datamodules.py
+++ b/crabs/detection_tracking/datamodules.py
@@ -152,19 +152,19 @@ class CrabsDataModule(LightningDataModule):
         """
         pass
 
-    def setup(self):
+    def setup(self, stage: str):  # type: ignore
         """Setup the data for training, testing and validation.
 
         Define the transforms for each split of the data and compute them.
         """
 
         # Assign transforms
-        # right now assuming validation and test get the same transform
+        # right now assuming validation and test get the same transforms
         self.train_transform = self._get_train_transform()
         self.test_transform = self._get_test_val_transform()
         self.val_transform = self._get_test_val_transform()
 
-        # Assign datasets for dataloader.
+        # Assign datasets
         self.train_dataset, _, _ = self._compute_splits(self.train_transform)
         _, self.test_dataset, _ = self._compute_splits(self.test_transform)
         _, _, self.val_dataset = self._compute_splits(self.val_transform)

--- a/crabs/detection_tracking/evaluate_model.py
+++ b/crabs/detection_tracking/evaluate_model.py
@@ -127,7 +127,7 @@ def main(args) -> None:
         config,
         args.seed_n,
     )
-    data_module.setup()
+    data_module.setup("test")
     data_loader = data_module.test_dataloader()
 
     # evaluator


### PR DESCRIPTION
We need to keep the `stage` argument in the setup of the datamodule, as it seems to be used internally. Otherwise we get:

```
TypeError: CrabsDataModule.setup() got an unexpected keyword argument 'stage'
```

Since it doesn't have a default value, in the eval module we also need to specify it when we call `setup` directly.