### PR TITLE
Changes the log to log every epoch

### DIFF
--- a/crabs/detection_tracking/config/faster_rcnn.yaml
+++ b/crabs/detection_tracking/config/faster_rcnn.yaml
@@ -1,13 +1,13 @@
 num_epochs: 250
 learning_rate: 0.00005
 wdecay: 0.00005
-batch_size_train: 2
+batch_size_train: 4
 batch_size_test: 1
 num_classes: 2
 save: True
 train_fraction: 0.8
 val_over_test_fraction: 0
-num_workers: 4
+num_workers: 7
 transform_brightness: 0.5
 transform_hue: 0.3
 gaussian_blur_params:

--- a/crabs/detection_tracking/config/faster_rcnn.yaml
+++ b/crabs/detection_tracking/config/faster_rcnn.yaml
@@ -1,4 +1,4 @@
-num_epochs: 4
+num_epochs: 250
 learning_rate: 0.00005
 wdecay: 0.00005
 batch_size_train: 2

--- a/crabs/detection_tracking/config/faster_rcnn.yaml
+++ b/crabs/detection_tracking/config/faster_rcnn.yaml
@@ -1,13 +1,13 @@
 num_epochs: 250
 learning_rate: 0.00005
 wdecay: 0.00005
-batch_size_train: 4
+batch_size_train: 2
 batch_size_test: 1
 num_classes: 2
 save: True
 train_fraction: 0.8
 val_over_test_fraction: 0
-num_workers: 7
+num_workers: 4
 transform_brightness: 0.5
 transform_hue: 0.3
 gaussian_blur_params:

--- a/crabs/detection_tracking/config/faster_rcnn.yaml
+++ b/crabs/detection_tracking/config/faster_rcnn.yaml
@@ -1,4 +1,4 @@
-num_epochs: 250
+num_epochs: 4
 learning_rate: 0.00005
 wdecay: 0.00005
 batch_size_train: 2

--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -23,7 +23,7 @@ def coco_category():
     return COCO_INSTANCE_CATEGORY_NAMES
 
 
-def save_model(model: torch.nn.Module):
+def save_model(model: torch.nn.Module) -> str:
     """
     Save the trained model.
 
@@ -34,7 +34,8 @@ def save_model(model: torch.nn.Module):
 
     Returns
     -------
-    None
+    str
+        Name of the saved model.
 
     Notes
     -----

--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -51,6 +51,7 @@ def save_model(model: torch.nn.Module):
     print(filename)
     torch.save(model, filename)
     print("Model Saved")
+    return filename
 
 
 def draw_bbox(

--- a/crabs/detection_tracking/models.py
+++ b/crabs/detection_tracking/models.py
@@ -54,16 +54,8 @@ class FasterRCNN(LightningModule):
         total_loss = sum(loss for loss in loss_dict.values())
 
         # Accumulate the loss over each step during the epoch
-        if "total_training_loss" not in self.training_step_outputs:
-            self.training_step_outputs[
-                "total_training_loss"
-            ] = total_loss.item()
-            self.training_step_outputs["num_batches"] = 1
-        else:
-            self.training_step_outputs[
-                "total_training_loss"
-            ] += total_loss.item()
-            self.training_step_outputs["num_batches"] += 1
+        self.training_step_outputs["total_training_loss"] += total_loss.item()
+        self.training_step_outputs["num_batches"] += 1
 
         return total_loss
 
@@ -77,7 +69,10 @@ class FasterRCNN(LightningModule):
         )
 
         # Reset the training_step_outputs for the next epoch
-        self.training_step_outputs = {}
+        self.training_step_outputs = {
+            "total_training_loss": 0.0,
+            "num_batches": 0,
+        }
 
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -47,6 +47,8 @@ class DectectorTrain:
         self.accelerator = args.accelerator
         self.seed_n = args.seed_n
         self.experiment_name = args.experiment_name
+        self.fast_dev_run = args.fast_dev_run
+        self.limit_train_batches = args.limit_train_batches
         self.load_config_yaml()
 
     def load_config_yaml(self):
@@ -113,6 +115,7 @@ class DectectorTrain:
 
         mlf_logger.log_hyperparams(self.config)
         mlf_logger.log_hyperparams({"split_seed": self.seed_n})
+        mlf_logger.log_hyperparams({"cli_args": self.args})
 
         lightning_model = FasterRCNN(self.config)
 
@@ -120,8 +123,8 @@ class DectectorTrain:
             max_epochs=self.config["num_epochs"],
             accelerator=self.accelerator,
             logger=mlf_logger,
-            fast_dev_run=self.args.fast_dev_run,
-            limit_train_batches=self.args.limit_train_batches,
+            fast_dev_run=self.fast_dev_run,
+            limit_train_batches=self.limit_train_batches,
         )
 
         # Run training

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -36,6 +36,7 @@ class DectectorTrain:
     """
 
     def __init__(self, args):
+        self.args = args
         self.config_file = args.config_file
         self.images_dirs = self.prep_img_directories(
             args.dataset_dirs  # args only?
@@ -119,6 +120,8 @@ class DectectorTrain:
             max_epochs=self.config["num_epochs"],
             accelerator=self.accelerator,
             logger=mlf_logger,
+            fast_dev_run=self.args.fast_dev_run,
+            limit_train_batches=self.args.limit_train_batches,
         )
 
         # Run training
@@ -126,7 +129,8 @@ class DectectorTrain:
 
         # Save model if required
         if self.config["save"]:
-            save_model(lightning_model)
+            model_filename = save_model(lightning_model)
+            mlf_logger.log_hyperparams({"model_filename": model_filename})
 
 
 def main(args) -> None:
@@ -190,6 +194,20 @@ def train_parse_args(args):
         type=int,
         default=42,
         help="seed for dataset splits",
+    )
+    parser.add_argument(
+        "--fast_dev_run",
+        action="store_true",
+        help="option to run only one batch and one epoch for debugging",
+    )
+    parser.add_argument(
+        "--limit_train_batches",
+        type=float,
+        default=1.0,
+        help=(
+            "option to run smaller training number per epoch for debugging."
+            "By default 1.0 (all the training set)"
+        ),
     )
     return parser.parse_args(args)
 


### PR DESCRIPTION
The `.log` function cannot force the api to log for every epoch even when set `on_epoch=True` and `on_step=False`.
[Seems like unresolved issue](https://github.com/Lightning-AI/pytorch-lightning/issues/3228).

Instead we do `.log_metric` and set `step=self.current_epoch`. The x-axis will say step but it is in epoch.

Few other small changes:

- log model_filename in the mlflow
- options for fast debugging:

1. `fast_dev_run` only run for one batch and one epoch.
2. `limit_train_batches` run every epochs with limited percentage of training data. 
