### PR TITLE
Compute test and validation splits in one go using the same transforms

### DIFF
--- a/crabs/detection_tracking/datamodules.py
+++ b/crabs/detection_tracking/datamodules.py
@@ -120,7 +120,7 @@ class CrabsDataModule(LightningDataModule):
         full_dataset = CrabsCocoDetection(
             self.list_img_dirs,
             self.list_annotation_files,
-            transforms=transforms_all_splits,  # self.train_transform,
+            transforms=transforms_all_splits,
             list_exclude_files=self.config.get(
                 "exclude_video_file_list"
             ),  # get value only if key exists
@@ -160,14 +160,16 @@ class CrabsDataModule(LightningDataModule):
 
         # Assign transforms
         # right now assuming validation and test get the same transforms
+        test_and_val_transform = self._get_test_val_transform()
         self.train_transform = self._get_train_transform()
-        self.test_transform = self._get_test_val_transform()
-        self.val_transform = self._get_test_val_transform()
+        self.test_transform = test_and_val_transform
+        self.val_transform = test_and_val_transform
 
         # Assign datasets
         self.train_dataset, _, _ = self._compute_splits(self.train_transform)
-        _, self.test_dataset, _ = self._compute_splits(self.test_transform)
-        _, _, self.val_dataset = self._compute_splits(self.val_transform)
+        _, self.test_dataset, self.val_dataset = self._compute_splits(
+            test_and_val_transform
+        )
 
     def train_dataloader(self) -> DataLoader:
         """Define dataloader for the training set"""


### PR DESCRIPTION
Right now we first need to create the dataset and then split it. The transforms are unfortunately defined when creating the dataset (there may be ways around this but haven't digged into it).

Since validation and test set will always have the same transforms, we reduce the repeated dataset generation by computing them in one go.