### PR TITLE
Remove DEFAULT_ANNOTATIONS_FILENAME definition in train script

### DIFF
--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -16,8 +16,6 @@ from crabs.detection_tracking.detection_utils import (
 )
 from crabs.detection_tracking.models import FasterRCNN
 
-DEFAULT_ANNOTATIONS_FILENAME = "VIA_JSON_combined_coco_gen.json"
-
 
 class DectectorTrain:
     """Training class for detector algorithm

--- a/tests/test_unit/test_train_model.py
+++ b/tests/test_unit/test_train_model.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from crabs.detection_tracking.train_model import (
+from crabs.detection_tracking.detection_utils import (
     DEFAULT_ANNOTATIONS_FILENAME as DEFAULT_ANNOT_FILENAME,
 )
 from crabs.detection_tracking.train_model import (


### PR DESCRIPTION
It should be imported from detection_utils (but it's actually not used here so I just deleted it)