### PR TITLE
Add slurm logs as mlflow artifacts

### DIFF
--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -166,22 +166,27 @@ class DectectorTrain:
         if not slurm_job_id:
             return
 
-        # if slurm array job: log out and err files as artifacts
-        if slurm_job_id and slurm_array_job_id:
-            slurm_task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
-            for ext in [".out", ".err"]:
-                trainer.logger.log_artifact(
-                    f"slurm_array.{slurm_array_job_id}-{slurm_task_id}.*.{ext}"  # does it work with wildcards?
-                )
-            return
-
-        # if single job: : log out and err files as artifacts
+        # if slurm job: log out and err files as artifacts
+        # the filenaming convention from the bash script is assumed
         elif slurm_job_id:
-            for ext in [".out", ".err"]:
-                trainer.logger.log_artifact(
-                    f"slurm.{slurm_job_id}.*.{ext}"  # does it work with wildcards?
-                )
-            return
+            slurm_node = os.environ.get("SLURMD_NODENAME")
+
+            # if array job
+            if slurm_array_job_id:
+                slurm_task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
+                for ext in [".out", ".err"]:
+                    trainer.logger.log_artifact(
+                        f"slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}"
+                    )
+                return
+
+            # if single job:
+            else:
+                for ext in [".out", ".err"]:
+                    trainer.logger.log_artifact(
+                        f"slurm.{slurm_job_id}.{slurm_node}.{ext}"
+                    )
+                return
 
     def train_model(self):
         # Create data module

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -177,7 +177,7 @@ class DectectorTrain:
                 for ext in ["out", "err"]:
                     logger.experiment.log_artifact(
                         logger.run_id,
-                        f"slurm_logs/slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}",
+                        f"slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}",
                     )
                 return
 
@@ -186,7 +186,7 @@ class DectectorTrain:
                 for ext in ["out", "err"]:
                     logger.experiment.log_artifact(
                         logger.run_id,
-                        f"slurm_logs/slurm.{slurm_job_id}.{slurm_node}.{ext}",
+                        f"slurm.{slurm_job_id}.{slurm_node}.{ext}",
                     )
                 return
 

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -158,7 +158,7 @@ class DectectorTrain:
             limit_train_batches=self.limit_train_batches,
         )
 
-    def slurm_logs_as_artifacts(self, trainer):
+    def slurm_logs_as_artifacts(self, logger):
         slurm_job_id = os.environ.get("SLURM_JOB_ID")
         slurm_array_job_id = os.environ.get("SLURM_ARRAY_JOB_ID")
 
@@ -175,16 +175,18 @@ class DectectorTrain:
             if slurm_array_job_id:
                 slurm_task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
                 for ext in [".out", ".err"]:
-                    trainer.logger.log_artifact(
-                        f"slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}"
+                    logger.experiment.log_artifact(
+                        logger.run_id,
+                        f"slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}",
                     )
                 return
 
             # if single job:
             else:
                 for ext in [".out", ".err"]:
-                    trainer.logger.log_artifact(
-                        f"slurm.{slurm_job_id}.{slurm_node}.{ext}"
+                    logger.experiment.log_artifact(
+                        logger.run_id,
+                        f"slurm.{slurm_job_id}.{slurm_node}.{ext}",
                     )
                 return
 
@@ -205,7 +207,7 @@ class DectectorTrain:
         trainer.fit(lightning_model, data_module)
 
         # if this is a slurm job: add slurm logs as artifacts
-        self.slurm_logs_as_artifacts(trainer)
+        self.slurm_logs_as_artifacts(trainer.logger)
 
 
 def main(args) -> None:

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -177,7 +177,7 @@ class DectectorTrain:
                 for ext in ["out", "err"]:
                     logger.experiment.log_artifact(
                         logger.run_id,
-                        f"slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}",
+                        f"slurm_logs/slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}",
                     )
                 return
 
@@ -186,7 +186,7 @@ class DectectorTrain:
                 for ext in ["out", "err"]:
                     logger.experiment.log_artifact(
                         logger.run_id,
-                        f"slurm.{slurm_job_id}.{slurm_node}.{ext}",
+                        f"slurm_logs/slurm.{slurm_job_id}.{slurm_node}.{ext}",
                     )
                 return
 

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -174,7 +174,7 @@ class DectectorTrain:
             # if array job
             if slurm_array_job_id:
                 slurm_task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
-                for ext in [".out", ".err"]:
+                for ext in ["out", "err"]:
                     logger.experiment.log_artifact(
                         logger.run_id,
                         f"slurm_array.{slurm_array_job_id}-{slurm_task_id}.{slurm_node}.{ext}",
@@ -183,7 +183,7 @@ class DectectorTrain:
 
             # if single job:
             else:
-                for ext in [".out", ".err"]:
+                for ext in ["out", "err"]:
                     logger.experiment.log_artifact(
                         logger.run_id,
                         f"slurm.{slurm_job_id}.{slurm_node}.{ext}",


### PR DESCRIPTION
To keep all together, this PR adds the slurm logs to the MLflow run artifacts.

The slurm logs filename format is assumed to be the one set in the training bash scripts.

### To check by launching a single job
1. Connect to the SWC HPC and git clone this repo (for example in your `scratch` space).
1. Edit `bash_scripts/run_training_single.sh` to:
	- install the version of the crabs package from this branch (`smg/add-slurm-logs-as-artifacts`, line 46)
	- add these two lines at the end:
		```
		--mlflow_folder /ceph/zoo/users/sminano/ml-runs-all/ml-runs-scratch \
 		--limit_train_batches 0.01
		```
1. Run `sbatch bash_scripts/run_training_single.sh`
1. Activate a conda environment with `mlflow` and run 
	```
	mlflow ui --backend-store-uri file:////ceph/zoo/users/sminano/ml-runs-all/ml-runs-scratch
	``` 
1. When the training job is complete, the artifacts should include the slurm logs 👀 

