### PR TITLE
Refactor mlflow logger setup to re-use in evaluation

### DIFF
--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -106,47 +106,8 @@ def set_mlflow_run_name() -> str:
     return run_name
 
 
-def setup_mlflow_logger(
-    experiment_name: str,
-    run_name: str,
-    mlflow_folder: str
-) -> MLFlowLogger:
-    """
-    Setup MLflow logger for a given experiment and run name.
-
-    It also adds metadata to the logger (CLI arguments and if a SLURM job,
-    SLURM metadata).
-
-    Parameters
-    ----------
-    experiment_name : str
-        Name of the experiment under which this run will be logged.
-    run_name : str
-        Name of the run.
-    mlflow_folder : str
-        Path to folder where to store MLflow outputs for this run.
-
-    Returns
-    -------
-    MLFlowLogger
-        A logger to record data for MLflow
-    """
-
-    # Setup logger
-    mlf_logger = MLFlowLogger(
-        experiment_name=experiment_name,
-        run_name=run_name,
-        tracking_uri=f"file:{Path(mlflow_folder)}"
-    )
-
-    return mlf_logger
-
-
 def setup_mlflow_logger_with_checkpointing(
-    experiment_name: str,
-    run_name: str,
-    ckpt_config: dict,
-    mlflow_folder: str
+    experiment_name: str, run_name: str, ckpt_config: dict, mlflow_folder: str
 ) -> MLFlowLogger:
     """
     Setup MLflow logger with checkpointing, for a given experiment and run
@@ -178,6 +139,42 @@ def setup_mlflow_logger_with_checkpointing(
         run_name=run_name,
         tracking_uri=f"file:{Path(mlflow_folder)}",
         log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
+    )
+
+    return mlf_logger
+
+
+def setup_mlflow_logger_no_checkpointing(
+    experiment_name: str, run_name: str, mlflow_folder: str
+) -> MLFlowLogger:
+    """
+    Setup MLflow logger for a given experiment and run name, without
+    checkpointing.
+
+    It also adds metadata to the logger (CLI arguments and if a SLURM job,
+    SLURM metadata).
+
+    Parameters
+    ----------
+    experiment_name : str
+        Name of the experiment under which this run will be logged.
+    run_name : str
+        Name of the run.
+    mlflow_folder : str
+        Path to folder where to store MLflow outputs for this run.
+
+    Returns
+    -------
+    MLFlowLogger
+        A logger to record data for MLflow
+    """
+
+    # Setup logger with empty dict as ckpt config
+    mlf_logger = setup_mlflow_logger_with_checkpointing(
+        experiment_name=experiment_name,
+        run_name=run_name,
+        mlflow_folder=mlflow_folder,
+        ckpt_config={},
     )
 
     return mlf_logger

--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -87,18 +87,18 @@ def set_mlflow_run_name() -> str:
     - if it is a single job use <job_ID>, else
     - if it is an array job use <job_ID_parent>_<task_ID>
     """
-    # Get slurm environment vars
+    # Get slurm environment variables
     slurm_job_id = os.environ.get("SLURM_JOB_ID")
     slurm_array_job_id = os.environ.get("SLURM_ARRAY_JOB_ID")
 
-    # If slurm array job
+    # If job is a slurm array job
     if slurm_job_id and slurm_array_job_id:
         slurm_task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
         run_name = f"run_slurm_{slurm_array_job_id}_{slurm_task_id}"
-    # If slurm single job
+    # If job is a slurm single job
     elif slurm_job_id:
         run_name = f"run_slurm_{slurm_job_id}"
-    # If not slurm: use timestamp
+    # If not a slurm job: use timestamp
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         run_name = f"run_{timestamp}"
@@ -112,9 +112,10 @@ def setup_mlflow_logger(
     mlflow_folder: str
 ) -> MLFlowLogger:
     """
-    Setup MLflow logger for a given experiment and run.
+    Setup MLflow logger for a given experiment and run name.
 
-    It also logs CLI arguments and SLURM metadata (if a SLURM job).
+    It also adds metadata to the logger (CLI arguments and if a SLURM job,
+    SLURM metadata).
 
     Parameters
     ----------
@@ -148,9 +149,11 @@ def setup_mlflow_logger_with_checkpointing(
     mlflow_folder: str
 ) -> MLFlowLogger:
     """
-    Setup MLflow logger with checkpointing, for a given experiment and run.
+    Setup MLflow logger with checkpointing, for a given experiment and run
+    name.
 
-    It also logs CLI arguments and SLURM metadata (if a SLURM job).
+    It also adds metadata to the logger (CLI arguments and if a SLURM job,
+    SLURM metadata).
 
     Parameters
     ----------
@@ -184,7 +187,8 @@ def log_metadata_to_logger(
     mlf_logger: MLFlowLogger,
     cli_args: argparse.Namespace,
 ) -> MLFlowLogger:
-    """Log metadata to MLflow logger.
+    """
+    Log metadata to MLflow logger.
 
     Add CLI arguments and, if available, SLURM job information.
 

--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -1,4 +1,9 @@
+import argparse
+import datetime
+import os
 from pathlib import Path
+
+from lightning.pytorch.loggers import MLFlowLogger
 
 DEFAULT_ANNOTATIONS_FILENAME = "VIA_JSON_combined_coco_gen.json"
 
@@ -71,3 +76,148 @@ def prep_annotation_files(
                 annotation_files.append(annot)
 
     return annotation_files
+
+
+def set_mlflow_run_name() -> str:
+    """
+    Set MLflow run name.
+
+    Use the slurm job ID if it is a SLURM job, else use a timestamp.
+    For SLURM jobs:
+    - if it is a single job use <job_ID>, else
+    - if it is an array job use <job_ID_parent>_<task_ID>
+    """
+    # Get slurm environment vars
+    slurm_job_id = os.environ.get("SLURM_JOB_ID")
+    slurm_array_job_id = os.environ.get("SLURM_ARRAY_JOB_ID")
+
+    # If slurm array job
+    if slurm_job_id and slurm_array_job_id:
+        slurm_task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
+        run_name = f"run_slurm_{slurm_array_job_id}_{slurm_task_id}"
+    # If slurm single job
+    elif slurm_job_id:
+        run_name = f"run_slurm_{slurm_job_id}"
+    # If not slurm: use timestamp
+    else:
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_name = f"run_{timestamp}"
+
+    return run_name
+
+
+def setup_mlflow_logger(
+    experiment_name: str,
+    run_name: str,
+    mlflow_folder: str
+) -> MLFlowLogger:
+    """
+    Setup MLflow logger for a given experiment and run.
+
+    It also logs CLI arguments and SLURM metadata (if a SLURM job).
+
+    Parameters
+    ----------
+    experiment_name : str
+        Name of the experiment under which this run will be logged.
+    run_name : str
+        Name of the run.
+    mlflow_folder : str
+        Path to folder where to store MLflow outputs for this run.
+
+    Returns
+    -------
+    MLFlowLogger
+        A logger to record data for MLflow
+    """
+
+    # Setup logger
+    mlf_logger = MLFlowLogger(
+        experiment_name=experiment_name,
+        run_name=run_name,
+        tracking_uri=f"file:{Path(mlflow_folder)}"
+    )
+
+    return mlf_logger
+
+
+def setup_mlflow_logger_with_checkpointing(
+    experiment_name: str,
+    run_name: str,
+    ckpt_config: dict,
+    mlflow_folder: str
+) -> MLFlowLogger:
+    """
+    Setup MLflow logger with checkpointing, for a given experiment and run.
+
+    It also logs CLI arguments and SLURM metadata (if a SLURM job).
+
+    Parameters
+    ----------
+    experiment_name : str
+        Name of the experiment under which this run will be logged.
+    run_name : str
+        Name of the run.
+    ckpt_config : dict
+        A dictionary with the checkpointing parameters.
+    mlflow_folder : str
+        Path to folder where to store MLflow outputs for this run.
+
+    Returns
+    -------
+    MLFlowLogger
+        A logger to record data for MLflow
+    """
+
+    # Setup logger with checkpointing
+    mlf_logger = MLFlowLogger(
+        experiment_name=experiment_name,
+        run_name=run_name,
+        tracking_uri=f"file:{Path(mlflow_folder)}",
+        log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
+    )
+
+    return mlf_logger
+
+
+def log_metadata_to_logger(
+    mlf_logger: MLFlowLogger,
+    cli_args: argparse.Namespace,
+) -> MLFlowLogger:
+    """Log metadata to MLflow logger.
+
+    Add CLI arguments and, if available, SLURM job information.
+
+    Parameters
+    ----------
+    mlf_logger : MLFlowLogger
+        An MLflow logger instance.
+    cli_args : argparse.Namespace
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    MLFlowLogger
+        An MLflow logger instance with metadata logged.
+    """
+
+    # Log CLI arguments
+    mlf_logger.log_hyperparams({"cli_args": cli_args})
+
+    # Log slurm metadata
+    slurm_job_id = os.environ.get("SLURM_JOB_ID")
+    slurm_array_job_id = os.environ.get("SLURM_ARRAY_JOB_ID")
+
+    # if array job
+    if slurm_job_id and slurm_array_job_id:
+        slurm_task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
+        mlf_logger.log_hyperparams(
+            {"slurm_job_id": slurm_array_job_id}
+        )  # ID of parent job
+        mlf_logger.log_hyperparams({"slurm_array_task_id": slurm_task_id})
+
+    # if single job
+    elif slurm_job_id:
+        mlf_logger.log_hyperparams({"slurm_job_id": slurm_job_id})
+
+    return mlf_logger

--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -106,15 +106,16 @@ def set_mlflow_run_name() -> str:
     return run_name
 
 
-def setup_mlflow_logger_with_checkpointing(
-    experiment_name: str, run_name: str, ckpt_config: dict, mlflow_folder: str
+def setup_mlflow_logger(
+    experiment_name: str,
+    run_name: str,
+    mlflow_folder: str,
+    ckpt_config: dict = {},
 ) -> MLFlowLogger:
     """
-    Setup MLflow logger with checkpointing, for a given experiment and run
-    name.
-
-    It also adds metadata to the logger (CLI arguments and if a SLURM job,
-    SLURM metadata).
+    Setup MLflow logger for a given experiment and run name. If a
+    checkpointing config is passed, it will setup the logger with a
+    checkpointing callback.
 
     Parameters
     ----------
@@ -122,10 +123,10 @@ def setup_mlflow_logger_with_checkpointing(
         Name of the experiment under which this run will be logged.
     run_name : str
         Name of the run.
-    ckpt_config : dict
-        A dictionary with the checkpointing parameters.
     mlflow_folder : str
         Path to folder where to store MLflow outputs for this run.
+    ckpt_config : dict
+        A dictionary with the checkpointing parameters. By default, an empty dict.
 
     Returns
     -------
@@ -139,42 +140,6 @@ def setup_mlflow_logger_with_checkpointing(
         run_name=run_name,
         tracking_uri=f"file:{Path(mlflow_folder)}",
         log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
-    )
-
-    return mlf_logger
-
-
-def setup_mlflow_logger_no_checkpointing(
-    experiment_name: str, run_name: str, mlflow_folder: str
-) -> MLFlowLogger:
-    """
-    Setup MLflow logger for a given experiment and run name, without
-    checkpointing.
-
-    It also adds metadata to the logger (CLI arguments and if a SLURM job,
-    SLURM metadata).
-
-    Parameters
-    ----------
-    experiment_name : str
-        Name of the experiment under which this run will be logged.
-    run_name : str
-        Name of the run.
-    mlflow_folder : str
-        Path to folder where to store MLflow outputs for this run.
-
-    Returns
-    -------
-    MLFlowLogger
-        A logger to record data for MLflow
-    """
-
-    # Setup logger with empty dict as ckpt config
-    mlf_logger = setup_mlflow_logger_with_checkpointing(
-        experiment_name=experiment_name,
-        run_name=run_name,
-        mlflow_folder=mlflow_folder,
-        ckpt_config={},
     )
 
     return mlf_logger

--- a/crabs/detection_tracking/evaluate_model.py
+++ b/crabs/detection_tracking/evaluate_model.py
@@ -53,6 +53,7 @@ class DetectorEvaluation:
         self.seed_n = args.seed_n
         self.ious_threshold = args.ious_threshold
         self.score_threshold = args.score_threshold
+        self.mlflow_folder = args.mlflow_folder
         self.load_config_yaml()
 
     def load_config_yaml(self):
@@ -73,8 +74,9 @@ class DetectorEvaluation:
 
         # Setup logger (no checkpointing)
         mlf_logger = setup_mlflow_logger(
-            "evaluation",
-            self.run_name,
+            experiment_name="Sep2023_evaluation",
+            run_name=self.run_name,
+            mlflow_folder=self.mlflow_folder,
         )
 
         # Log metadata to logger: CLI arguments and SLURM (if required)
@@ -205,6 +207,12 @@ def evaluate_parse_args(args):
         type=int,
         default=42,
         help="Seed for dataset splits. Default: 42",
+    )
+    parser.add_argument(
+        "--mlflow_folder",
+        type=str,
+        default="./ml-runs",
+        help=("Path to MLflow directory. Default: ./ml-runs"),
     )
     parser.add_argument(
         "--save_frames",

--- a/crabs/detection_tracking/evaluate_model.py
+++ b/crabs/detection_tracking/evaluate_model.py
@@ -1,5 +1,4 @@
 import argparse
-import datetime
 import sys
 from pathlib import Path
 
@@ -9,8 +8,11 @@ from lightning.pytorch.loggers import MLFlowLogger
 
 from crabs.detection_tracking.datamodules import CrabsDataModule
 from crabs.detection_tracking.detection_utils import (
+    log_metadata_to_logger,
     prep_annotation_files,
     prep_img_directories,
+    set_mlflow_run_name,
+    setup_mlflow_logger,
 )
 from crabs.detection_tracking.models import FasterRCNN
 from crabs.detection_tracking.visualization import save_images_with_boxes
@@ -57,11 +59,48 @@ class DetectorEvaluation:
         with open(self.config_file, "r") as f:
             self.config = yaml.safe_load(f)
 
+    def set_run_name(self):
+        self.run_name = set_mlflow_run_name()
+
+    def setup_logger(self) -> MLFlowLogger:
+        """
+        Setup MLflow logger for testing.
+
+        Includes logging metadata about the job (CLI arguments and SLURM job IDs).
+        """
+        # Assign run name
+        self.set_run_name()
+
+        # Setup logger (no checkpointing)
+        mlf_logger = setup_mlflow_logger(
+            "evaluation",
+            self.run_name,
+        )
+
+        # Log metadata to logger: CLI arguments and SLURM (if required)
+        mlf_logger = log_metadata_to_logger(mlf_logger, self.args)
+
+        return mlf_logger
+
+    def setup_trainer(self):
+        """
+        Setup trainer object with logging for testing.
+        """
+
+        # Get MLflow logger
+        mlf_logger = self.setup_logger()
+
+        # Return trainer linked to logger
+        return lightning.Trainer(
+            accelerator=self.args.accelerator,
+            logger=mlf_logger,
+        )
+
     def evaluate_model(self) -> None:
         """
         Evaluate the trained model on the test dataset.
         """
-        # instantiate datamodule for the given seed and manually setup
+        # Create datamodule
         data_module = CrabsDataModule(
             self.images_dirs,
             self.annotation_files,
@@ -69,34 +108,19 @@ class DetectorEvaluation:
             self.seed_n,
         )
 
-        # start mlflow logger
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        run_name = f"run_{timestamp}"
-        mlf_logger = MLFlowLogger(
-            run_name=run_name,
-            experiment_name="evaluation",
-            tracking_uri="file:./ml-runs",
-        )
-        mlf_logger.log_hyperparams(self.config)
-        mlf_logger.log_hyperparams({"split_seed": self.seed_n})
-        mlf_logger.log_hyperparams({"cli_args": self.args})
-
-        # instantiate trainer
-        trainer = lightning.Trainer(
-            accelerator=self.args.accelerator,
-            logger=mlf_logger,
-        )
-
-        # run test
+        # Get trained model
         trained_model = FasterRCNN.load_from_checkpoint(
             self.args.checkpoint_path
         )
+
+        # Run testing
+        trainer = self.setup_trainer()
         trainer.test(
             trained_model,
             data_module,
         )
 
-        # save images if required
+        # Save images if required
         if self.args.save_frames:
             save_images_with_boxes(
                 data_module.test_dataloader(),

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -74,10 +74,10 @@ class DectectorTrain:
 
         # Setup logger with checkpointing
         mlf_logger = setup_mlflow_logger_with_checkpointing(
-            self.experiment_name,
-            self.run_name,
-            self.mlflow_folder,
-            self.config.get("checkpoint_saving", {}),
+            experiment_name=self.experiment_name,
+            run_name=self.run_name,
+            mlflow_folder=self.mlflow_folder,
+            ckpt_config=self.config.get("checkpoint_saving", {}),
         )
 
         # Log metadata: CLI arguments and SLURM (if required)

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -14,7 +14,7 @@ from crabs.detection_tracking.detection_utils import (
     prep_annotation_files,
     prep_img_directories,
     set_mlflow_run_name,
-    setup_mlflow_logger_with_checkpointing,
+    setup_mlflow_logger,
 )
 from crabs.detection_tracking.models import FasterRCNN
 
@@ -73,7 +73,7 @@ class DectectorTrain:
         self.set_run_name()
 
         # Setup logger with checkpointing
-        mlf_logger = setup_mlflow_logger_with_checkpointing(
+        mlf_logger = setup_mlflow_logger(
             experiment_name=self.experiment_name,
             run_name=self.run_name,
             mlflow_folder=self.mlflow_folder,

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
This PR moves some of the MLflow logger setup functions to `detection_utils`, so that they are shared in the training and eval script.