### PR TITLE
Fix MLflow folder error

### DIFF
--- a/bash_scripts/run_training_array.sh
+++ b/bash_scripts/run_training_array.sh
@@ -110,3 +110,4 @@ train-detector  \
  --accelerator gpu \
  --experiment_name "Sept2023" \
  --seed_n $SPLIT_SEED \
+ --mlflow_folder /ceph/zoo/users/sminano/ml-runs \

--- a/bash_scripts/run_training_single.sh
+++ b/bash_scripts/run_training_single.sh
@@ -95,3 +95,4 @@ train-detector  \
  --accelerator gpu \
  --experiment_name "Sept2023" \
  --seed_n $SPLIT_SEED \
+ --mlflow_folder /ceph/zoo/users/sminano/ml-runs \

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -100,7 +100,7 @@ class DectectorTrain:
         mlf_logger = MLFlowLogger(
             experiment_name=self.experiment_name,
             run_name=self.run_name,
-            tracking_uri=f"file:{self.mlflow_folder}",
+            tracking_uri=f"file:{self.mlflow_folder.encode('unicode_escape')}",
             log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
         )
 
@@ -261,10 +261,8 @@ def train_parse_args(args):
     parser.add_argument(
         "--mlflow_folder",
         type=str,
-        default="/ceph/zoo/users/sminano/ml-runs",
-        help=(
-            "Path to MLflow directory. Default: /ceph/zoo/users/sminano/ml-runs"
-        ),
+        default="./ml-runs",
+        help=("Path to MLflow directory. Default: ./ml-runs"),
     )
 
     return parser.parse_args(args)


### PR DESCRIPTION
This PR fixes the utf-8 encoding error we were getting with MLflow logger. 

The path passed needs to be a 'raw' string (the forward slashes need to be escaped).

I also changed the default location for the `ml-runs` to be under the current working directory. When we launch a job in the cluster (using `run_training....sh`), I set the MLflow folder argument to be the one we agreed in ceph. Let me know thoughts, I think this would be the most convenient.

I checked this fix works: locally, with an interactive node, with a batch job.