### PR TITLE
Fix MLflow folder issue with pathlib

### DIFF
--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -100,7 +100,7 @@ class DectectorTrain:
         mlf_logger = MLFlowLogger(
             experiment_name=self.experiment_name,
             run_name=self.run_name,
-            tracking_uri=f"file:{str(Path(self.mlflow_folder))}",
+            tracking_uri=f"file:{Path(self.mlflow_folder)}",
             log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
         )
 

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -261,7 +261,7 @@ def train_parse_args(args):
     parser.add_argument(
         "--mlflow_folder",
         type=str,
-        default=str(Path("./ml-runs")),
+        default="./ml-runs",
         help=("Path to MLflow directory. Default: ./ml-runs"),
     )
 

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -100,7 +100,7 @@ class DectectorTrain:
         mlf_logger = MLFlowLogger(
             experiment_name=self.experiment_name,
             run_name=self.run_name,
-            tracking_uri=f"file:{self.mlflow_folder.encode('unicode_escape')}",
+            tracking_uri=f"file:{str(Path(self.mlflow_folder))}",
             log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
         )
 
@@ -261,7 +261,7 @@ def train_parse_args(args):
     parser.add_argument(
         "--mlflow_folder",
         type=str,
-        default="./ml-runs",
+        default=str(Path("./ml-runs")),
         help=("Path to MLflow directory. Default: ./ml-runs"),
     )
 


### PR DESCRIPTION
A much better fix (that actually works 😅 )

To check:
1. Connect to SWC HPC and git clone the repo
2. Edit `bash_scripts/run_training_single.sh` temporarily:
    - to install the crab package with the version of this branch (`smg/fix-paths-mlflow-folder`, line 46)
    - (optional): edit `--mlflow_folder` (line 98) to point to a location where you can quickly check if it's created
    - (optional): add `--limit_train_batches 0.01` and edit the config to run for 1 epoch only
3. Launch the job with `sbatch bash_scripts/run_training_single.sh`
4. It should create an `ml-run` folder where it was told