### PR TITLE
Proposed structure for `ml-run`

### DIFF
--- a/bash_scripts/run_training_array.sh
+++ b/bash_scripts/run_training_array.sh
@@ -110,4 +110,4 @@ train-detector  \
  --accelerator gpu \
  --experiment_name "Sept2023" \
  --seed_n $SPLIT_SEED \
- --mlflow_folder /ceph/zoo/users/sminano/ml-runs \
+ --mlflow_folder /ceph/zoo/users/sminano/ml-runs-all/ml-runs-scratch \

--- a/bash_scripts/run_training_single.sh
+++ b/bash_scripts/run_training_single.sh
@@ -95,4 +95,4 @@ train-detector  \
  --accelerator gpu \
  --experiment_name "Sept2023" \
  --seed_n $SPLIT_SEED \
- --mlflow_folder /ceph/zoo/users/sminano/ml-runs \
+ --mlflow_folder /ceph/zoo/users/sminano/ml-runs-all/ml-runs-scratch \


### PR DESCRIPTION
To be a bit more consistent with the training jobs we run, we agreed to have a common `ml-runs` folder. 

However, during development we often do debugging runs. For that it seems useful to have a "scratch" `ml-runs` folder.

I propose the following structure:
Under `/ceph/zoo/users/sminano/ml-runs-all` we have:
- `ml-runs-scratch` to hold temp runs, which we can regularly empty with no fear.
- `ml-runs`, where we hold the training jobs that we want to consider for evaluation
- any other useful / backup old runs we want (for example right now `ml-runs-sminano-copy`)

The idea is that we launch training jobs in the cluster identically, i.e., both of us using the bash script from the repo (preferably the job array one for jobs we want to consider for evaluation).

In this PR, I set the 'scratch' mlruns as the "default" path in the bash script. The idea is not to bloat the `ml-runs` folder with test runs, which seem far more common atm.

Note: I call it "scratch" ml-runs folder, but it is not actually in the "scratch" part of `ceph`, so it is actually backed up and we can recover runs if we need them.
