### PR TITLE
MOTA revisited 

### DIFF
--- a/tests/test_unit/test_tracking_utils.py
+++ b/tests/test_unit/test_tracking_utils.py
@@ -17,26 +17,23 @@ from crabs.detection_tracking.tracking_utils import (
 
 
 @pytest.mark.parametrize(
-    "prev_frame_id, current_frame_id, expected_output",
+    "prev_frame_id, current_frame_id, n_gt, expected_output",
     [
-        (None, [[6, 5, 4, 3, 2, 1]], 0),
-        (
-            [[6, 5, 4, 3, 2, 1]],
-            [[6, 5, 4, 3, 2, 1]],
-            0,
-        ),  # no identity switches
-        ([[5, 6, 4, 3, 1, 2]], [[6, 5, 4, 3, 2, 1]], 0),
-        ([[6, 5, 4, 3, 2, 1]], [[6, 5, 4, 2, 1]], 1),
-        ([[6, 5, 4, 2, 1]], [[6, 5, 4, 2, 1, 7]], 1),
-        ([[6, 5, 4, 2, 1, 7]], [[6, 5, 4, 2, 7, 8]], 2),
-        ([[6, 5, 4, 2, 7, 8]], [[6, 5, 4, 2, 7, 8, 3]], 1),
+        (None, [[6, 5, 4, 3, 2, 1]], 6, 0),
+        ([[6, 5, 4, 3, 2, 1]], [[6, 5, 4, 3, 2, 1]], 6, 0),
+        ([[5, 6, 4, 3, 1, 2]], [[6, 5, 4, 3, 2, 1]], 6, 0),
+        ([[6, 5, 4, 3, 2, 1]], [[6, 5, 4, 2, 1]], 5, 0),
+        ([[6, 5, 4, 3, 2, 1]], [[6, 5, 4, 2, 1, 7]], 6, 1),
+        ([[6, 5, 4, 2, 1]], [[6, 5, 4, 2, 7]], 5, 1),
+        ([[6, 5, 4, 3, 2]], [[6, 5, 4, 2, 7, 8, 3]], 5, 2),
+        ([[6, 5, 4, 3]], [[6, 5, 4, 3, 7, 8, 9]], 5, 3),
     ],
 )
 def test_count_identity_switches(
-    prev_frame_id, current_frame_id, expected_output
+    prev_frame_id, current_frame_id, n_gt, expected_output
 ):
     assert (
-        count_identity_switches(prev_frame_id, current_frame_id)
+        count_identity_switches(prev_frame_id, current_frame_id, n_gt)
         == expected_output
     )
 


### PR DESCRIPTION
- The old way of getting the ID switch is by finding the symmetric_difference between two list. The problem with this if we have `prev_id = [1, 2, 3]` and `current_id = [1, 2, 4]` the `n_switches =2`. 
- The new approach will be 1. 
- We also now have more check on the id list. So if  `prev_id = [1, 2, 3]` and `current_id = [1, 2]` with `total_gt = 2`, `n_switches = 0`. 
-  But,  if  `prev_id = [1, 2, 3]` and `current_id = [1, 2]` with `total_gt = 3`, `n_switches = 0` because this is missed_detection.
- Similarly,  if  `prev_id = [1, 2, 3]` and `current_id = [1, 2, 3, 4]` with `total_gt = 3`, `n_switches = 0` because this is false_positive.
- Because of that, we now only considering the IDs that have been matched to ground truth as `current_id` to avoid double counting. 
- Some changes for the test -- feel free to play around with the value in the test to see any other possibility.