### PR TITLE
Refactor setup of loggers

### DIFF
--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -228,6 +228,31 @@ def setup_logger_with_checkpointing(
     return mlf_logger
 
 
+def setup_logger_without_checkpointing(
+    experiment_name: str,
+    run_name: str,
+    mlflow_folder: str,
+    cli_args: argparse.Namespace,
+):
+    """
+    Setup MLflow logger without checkpointing.
+
+    Includes logging metadata about the job (CLI arguments and SLURM job IDs).
+    """
+
+    # Setup logger with checkpointing
+    mlf_logger = setup_mlflow_logger(
+        experiment_name=experiment_name,
+        run_name=run_name,
+        mlflow_folder=mlflow_folder,
+    )
+
+    # Log metadata: CLI arguments and SLURM (if required)
+    mlf_logger = log_metadata_to_logger(mlf_logger, cli_args)
+
+    return mlf_logger
+
+
 def slurm_logs_as_artifacts(logger, slurm_job_id):
     """
     Add slurm logs as an MLflow artifacts of the current run.

--- a/crabs/detection_tracking/detection_utils.py
+++ b/crabs/detection_tracking/detection_utils.py
@@ -107,45 +107,6 @@ def set_mlflow_run_name() -> str:
     return run_name
 
 
-def setup_mlflow_logger(
-    experiment_name: str,
-    run_name: str,
-    mlflow_folder: str,
-    ckpt_config: dict = {},
-) -> MLFlowLogger:
-    """
-    Setup MLflow logger for a given experiment and run name. If a
-    checkpointing config is passed, it will setup the logger with a
-    checkpointing callback.
-
-    Parameters
-    ----------
-    experiment_name : str
-        Name of the experiment under which this run will be logged.
-    run_name : str
-        Name of the run.
-    mlflow_folder : str
-        Path to folder where to store MLflow outputs for this run.
-    ckpt_config : dict
-        A dictionary with the checkpointing parameters. By default, an empty dict.
-
-    Returns
-    -------
-    MLFlowLogger
-        A logger to record data for MLflow
-    """
-
-    # Setup logger with checkpointing
-    mlf_logger = MLFlowLogger(
-        experiment_name=experiment_name,
-        run_name=run_name,
-        tracking_uri=f"file:{Path(mlflow_folder)}",
-        log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
-    )
-
-    return mlf_logger
-
-
 def log_metadata_to_logger(
     mlf_logger: MLFlowLogger,
     cli_args: argparse.Namespace,
@@ -190,65 +151,66 @@ def log_metadata_to_logger(
     return mlf_logger
 
 
-def setup_logger_with_checkpointing(
-    experiment_name: str,
-    run_name: str,
-    mlflow_folder: str,
-    ckpt_config: dict[str, Any],
-    cli_args: argparse.Namespace,
-):
-    """
-    Setup MLflow logger with checkpointing.
-
-    Includes logging metadata about the job (CLI arguments and SLURM job IDs).
-    """
-
-    # Setup logger with checkpointing
-    mlf_logger = setup_mlflow_logger(
-        experiment_name=experiment_name,
-        run_name=run_name,
-        mlflow_folder=mlflow_folder,
-        ckpt_config=ckpt_config,
-    )
-
-    # Log metadata: CLI arguments and SLURM (if required)
-    mlf_logger = log_metadata_to_logger(mlf_logger, cli_args)
-
-    # Log (assumed) path to checkpoints directory
-    path_to_checkpoints = (
-        Path(mlf_logger._tracking_uri)
-        / mlf_logger._experiment_id
-        / mlf_logger._run_id
-        / "checkpoints"
-    )
-    mlf_logger.log_hyperparams(
-        {"path_to_checkpoints": str(path_to_checkpoints)}
-    )
-
-    return mlf_logger
-
-
-def setup_logger_without_checkpointing(
+def setup_mlflow_logger(
     experiment_name: str,
     run_name: str,
     mlflow_folder: str,
     cli_args: argparse.Namespace,
-):
+    ckpt_config: dict[str, Any] = {},
+) -> MLFlowLogger:
     """
-    Setup MLflow logger without checkpointing.
+    Setup MLflow logger and log job metadata, with optional checkpointing.
 
-    Includes logging metadata about the job (CLI arguments and SLURM job IDs).
+    Setup MLflow logger for a given experiment and run name. If a
+    checkpointing config is passed, it will setup the logger with a
+    checkpointing callback. A job metadata is the job's CLI arguments and
+    the SLURM job IDs (if relevant).
+
+
+    Parameters
+    ----------
+    experiment_name : str
+        Name of the experiment under which this run will be logged.
+    run_name : str
+        Name of the run.
+    mlflow_folder : str
+        Path to folder where to store MLflow outputs for this run.
+    cli_args : argparse.Namespace
+        Parsed command-line arguments.
+    ckpt_config : dict
+        A dictionary with the checkpointing parameters.
+        By default, an empty dict.
+
+    Returns
+    -------
+    MLFlowLogger
+        A logger to record data for MLflow
     """
 
-    # Setup logger with checkpointing
-    mlf_logger = setup_mlflow_logger(
+    # Setup MLflow logger for a given experiment and run name
+    # (with checkpointing if required)
+    mlf_logger = MLFlowLogger(
         experiment_name=experiment_name,
         run_name=run_name,
-        mlflow_folder=mlflow_folder,
+        tracking_uri=f"file:{Path(mlflow_folder)}",
+        log_model=ckpt_config.get("copy_as_mlflow_artifacts", False),
     )
 
-    # Log metadata: CLI arguments and SLURM (if required)
+    # Log metadata: CLI arguments and SLURM job ID (if required)
     mlf_logger = log_metadata_to_logger(mlf_logger, cli_args)
+
+    # If checkpointing is not an empty dict,
+    # log the path to the checkpoints directory
+    if ckpt_config:
+        path_to_checkpoints = (
+            Path(mlf_logger._tracking_uri)
+            / mlf_logger._experiment_id
+            / mlf_logger._run_id
+            / "checkpoints"
+        )
+        mlf_logger.log_hyperparams(
+            {"path_to_checkpoints": str(path_to_checkpoints)}
+        )
 
     return mlf_logger
 

--- a/crabs/detection_tracking/evaluate_model.py
+++ b/crabs/detection_tracking/evaluate_model.py
@@ -8,11 +8,10 @@ from lightning.pytorch.loggers import MLFlowLogger
 
 from crabs.detection_tracking.datamodules import CrabsDataModule
 from crabs.detection_tracking.detection_utils import (
-    log_metadata_to_logger,
     prep_annotation_files,
     prep_img_directories,
     set_mlflow_run_name,
-    setup_mlflow_logger,
+    setup_logger_without_checkpointing,
 )
 from crabs.detection_tracking.models import FasterRCNN
 from crabs.detection_tracking.visualization import save_images_with_boxes
@@ -73,14 +72,12 @@ class DetectorEvaluation:
         self.set_run_name()
 
         # Setup logger (no checkpointing)
-        mlf_logger = setup_mlflow_logger(
+        mlf_logger = setup_logger_without_checkpointing(
             experiment_name="Sep2023_evaluation",
             run_name=self.run_name,
             mlflow_folder=self.mlflow_folder,
+            cli_args=self.args,
         )
-
-        # Log metadata to logger: CLI arguments and SLURM (if required)
-        mlf_logger = log_metadata_to_logger(mlf_logger, self.args)
 
         return mlf_logger
 

--- a/crabs/detection_tracking/evaluate_model.py
+++ b/crabs/detection_tracking/evaluate_model.py
@@ -11,7 +11,7 @@ from crabs.detection_tracking.detection_utils import (
     prep_annotation_files,
     prep_img_directories,
     set_mlflow_run_name,
-    setup_logger_without_checkpointing,
+    setup_mlflow_logger,
 )
 from crabs.detection_tracking.models import FasterRCNN
 from crabs.detection_tracking.visualization import save_images_with_boxes
@@ -71,8 +71,8 @@ class DetectorEvaluation:
         # Assign run name
         self.set_run_name()
 
-        # Setup logger (no checkpointing)
-        mlf_logger = setup_logger_without_checkpointing(
+        # Setup logger
+        mlf_logger = setup_mlflow_logger(
             experiment_name="Sep2023_evaluation",
             run_name=self.run_name,
             mlflow_folder=self.mlflow_folder,

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -14,7 +14,7 @@ from crabs.detection_tracking.detection_utils import (
     prep_annotation_files,
     prep_img_directories,
     set_mlflow_run_name,
-    setup_logger_with_checkpointing,
+    setup_mlflow_logger,
     slurm_logs_as_artifacts,
 )
 from crabs.detection_tracking.models import FasterRCNN
@@ -70,12 +70,13 @@ class DectectorTrain:
         self.set_run_name()
 
         # Setup logger with checkpointing
-        mlf_logger = setup_logger_with_checkpointing(
+        mlf_logger = setup_mlflow_logger(
             experiment_name=self.experiment_name,
             run_name=self.run_name,
             mlflow_folder=self.mlflow_folder,
-            ckpt_config=self.config.get("checkpoint_saving", {}),
             cli_args=self.args,
+            ckpt_config=self.config.get("checkpoint_saving", {}),
+            # pass the checkpointing config if defined
         )
 
         return mlf_logger

--- a/crabs/detection_tracking/train_model.py
+++ b/crabs/detection_tracking/train_model.py
@@ -11,11 +11,10 @@ from lightning.pytorch.loggers import MLFlowLogger
 
 from crabs.detection_tracking.datamodules import CrabsDataModule
 from crabs.detection_tracking.detection_utils import (
-    log_metadata_to_logger,
     prep_annotation_files,
     prep_img_directories,
     set_mlflow_run_name,
-    setup_mlflow_logger,
+    setup_logger_with_checkpointing,
     slurm_logs_as_artifacts,
 )
 from crabs.detection_tracking.models import FasterRCNN
@@ -71,25 +70,12 @@ class DectectorTrain:
         self.set_run_name()
 
         # Setup logger with checkpointing
-        mlf_logger = setup_mlflow_logger(
+        mlf_logger = setup_logger_with_checkpointing(
             experiment_name=self.experiment_name,
             run_name=self.run_name,
             mlflow_folder=self.mlflow_folder,
             ckpt_config=self.config.get("checkpoint_saving", {}),
-        )
-
-        # Log metadata: CLI arguments and SLURM (if required)
-        mlf_logger = log_metadata_to_logger(mlf_logger, self.args)
-
-        # Log (assumed) path to checkpoints directory
-        path_to_checkpoints = (
-            Path(mlf_logger._tracking_uri)
-            / mlf_logger._experiment_id
-            / mlf_logger._run_id
-            / "checkpoints"
-        )
-        mlf_logger.log_hyperparams(
-            {"path_to_checkpoints": str(path_to_checkpoints)}
+            cli_args=self.args,
         )
 
         return mlf_logger


### PR DESCRIPTION
This PR comes from work in PR #136 and suggests a refactoring of the `setup_loggers` functions that keeps the structure of `train_model.py` and `evaluate_model.py` consistent.

It defines:
1-  a `setup_logger_with_checkpointing` function in `detection_utils.py` that defines a logger with checkpointing.
2- a `setup_logger_without_checkpointing` function in `detection_utils.py` for a logger without checkpointing.
3- then we import these functions in `train_model.py` and `evaluate_model.py` for their specific `self.setup_logger()` methods. (And we can import that in the optuna code too in the future #188 )
