### PR TITLE
Optuna fix: sample learning rate from log domain

### DIFF
--- a/crabs/detector/train_model.py
+++ b/crabs/detector/train_model.py
@@ -136,6 +136,7 @@ class DectectorTrain:
                 "learning_rate",
                 float(optuna_config["learning_rate"][0]),
                 float(optuna_config["learning_rate"][1]),
+                log=True
             )
 
         if "n_epochs" in optuna_config:

--- a/crabs/detector/train_model.py
+++ b/crabs/detector/train_model.py
@@ -136,7 +136,7 @@ class DectectorTrain:
                 "learning_rate",
                 float(optuna_config["learning_rate"][0]),
                 float(optuna_config["learning_rate"][1]),
-                log=True
+                log=True,
             )
 
         if "n_epochs" in optuna_config:


### PR DESCRIPTION
I think we need to set `log=True` so that we sample the learning rate from the log space.