### PR TITLE
Fix draw_detection to work with batch_size > 1

### DIFF
--- a/tests/test_unit/test_visualization.py
+++ b/tests/test_unit/test_visualization.py
@@ -7,7 +7,7 @@ import torch
 
 from crabs.detector.utils.visualization import (
     draw_bbox,
-    draw_detection,
+    draw_bboxes_on_images,
     save_images_with_boxes,
 )
 
@@ -146,7 +146,7 @@ def test_draw_bbox_green(sample_image, top_left, bottom_right, color):
 )
 def test_draw_detection(annotations, detections):
     imgs = [torch.rand(3, 100, 100)]
-    image_with_boxes = draw_detection(imgs, annotations, detections)
+    image_with_boxes = draw_bboxes_on_images(imgs, annotations, detections)
     assert image_with_boxes is not None
 
 


### PR DESCRIPTION
Fix draw_detection to work with batch_size > 1
- atm `draw_detection` saves one image per batch, rather than every image.
- this PR fixes that by returning a list instead.

TODO
- review use of `device` in the visualisation function
	- in `draw_detection` we assign to the selected device, but then copy it back to the cpu.
- add tests to be more comprehensive
- refactor visualisation module
