### PR TITLE
Fix tracking evaluation

### DIFF
--- a/crabs/tracker/README.md
+++ b/crabs/tracker/README.md
@@ -14,10 +14,10 @@ The configurable parameters of the tracker are defined in `crabs-exploration/cra
 We evaluate the performance of the tracker against manually labelled ground-truth. This ground-truth consists of manually annotated bounding boxes and IDs. We use MOTA (Multiple Object Tracking Accuracy) as a metric to evaluate performance. For each frame in the manually labelled clip, we can compute MOTA as:
 
 ```
-MOTA = 1 - ((FN + FP + IDs) / GT)
+MOTA = 1 - ((FN + FP + IDS) / GT)
 ```
 
-where `FN` is the number of false negatives (missed detections), `FP` is the number of false positives, `IDs` is the number of identity switches, and `GT` is the total number of ground-truth objects. The higher the MOTA value, the better the tracking performance. Note that the MOTA metric is upper-bounded by 1, and lower-bounded by -Inf. For a full video clip, we report the average MOTA across frames.
+where `FN` is the number of false negatives (missed detections), `FP` is the number of false positives, `IDS` is the number of identity switches, and `GT` is the total number of ground-truth objects. The higher the MOTA value, the better the tracking performance. Note that the MOTA metric is upper-bounded by 1, and lower-bounded by -Inf. For a full video clip, we compute the MOTA per frame, and report the average MOTA across all frames.
 
 To compute the total number of false negatives (or missed detections, `FN`) at a given frame `f`, we count the number of ground-truth objects that do not match with any detection at frame `f`. A ground-truth object and a detection are considered to match if their associated boxes sufficiently overlap, that is, if their intersection-over-union (IOU) is greater than a given threshold.
 
@@ -25,9 +25,11 @@ To compute the total number of false positives (`FP`) at a given frame `f`, we c
 
 A true positive (`TP`) is defined as a detection that sufficiently overlaps with a ground-truth box (with overlap measured with the `IOU` metric).
 
-To compute the number of identity switches (`IDs`) at a given frame `f` we inspect the set of true positives, and check if for each of their ground-truth IDs, the predicted ID at frame `f` matches the predicted ID at the last frame `f-1` the object was detected. If the predicted IDs do not match for the same ground-truth ID, we count that as one identity switch.
+To compute the number of identity switches (`IDS`) we inspect the set of true positives. Given two mappings from ground-truth IDs to predicted IDs, for the previous frame `f-1` and for the current frame `f`, we compute the total number of identity switches (`IDS`) as the sum of:
+- the number of **re-identifications**, that is, the number of times the same ground-truth ID maps to two different predicted IDs in the current and the previous frame. If the predicted ID in the previous frame is not defined (because it was a missed detection or because there was no ground-truth defined for it), we use the last predicted ID associated to that ground-truth ID if available.
+- the number of **identity swaps**, that is, the number of times the same predicted ID maps to two different ground-truth IDs in the current and previous frame.
 
-This is slightly different to some MOTA definitions, which only account for identity switches between consecutive frames. It is also different from other implementations, which define an "expected" predicted ID for each ground-truth ID. This "expected" predicted ID is the predicted ID that is most often (in terms of number of frames) associated to a ground-truth ID.
+Note that this definition of identity switches is slightly different to some MOTA definitions, which only account for identity switches between consecutive frames. It is also different from other implementations, which define an "expected" predicted ID for each ground-truth ID. This "expected" predicted ID is the predicted ID that is most often (in terms of number of frames) associated to a ground-truth ID.
 
 ## References and useful resources
 

--- a/crabs/tracker/README.md
+++ b/crabs/tracker/README.md
@@ -29,7 +29,7 @@ To compute the number of identity switches (`IDS`) we inspect the set of true po
 - the number of **re-identifications**, that is, the number of times the same ground-truth ID maps to two different predicted IDs in the current and the previous frame. If the predicted ID in the previous frame is not defined (because it was a missed detection or because there was no ground-truth defined for it), we use the last predicted ID associated to that ground-truth ID if available.
 - the number of **identity swaps**, that is, the number of times the same predicted ID maps to two different ground-truth IDs in the current and previous frame.
 
-Note that this definition of identity switches is slightly different to some MOTA definitions, which only account for identity switches between consecutive frames. It is also different from other implementations, which define an "expected" predicted ID for each ground-truth ID. This "expected" predicted ID is the predicted ID that is most often (in terms of number of frames) associated to a ground-truth ID.
+Note that this definition of identity switches is slightly different to some other MOTA definitions, which only account for identity switches between consecutive frames. It is also different from other implementations, which define an "expected" predicted ID for each ground-truth ID. This "expected" predicted ID is the predicted ID that is most often (in terms of number of frames) associated to a ground-truth ID.
 
 ## References and useful resources
 

--- a/crabs/tracker/evaluate_tracker.py
+++ b/crabs/tracker/evaluate_tracker.py
@@ -202,6 +202,7 @@ class TrackerEvaluate:
         # Count cases a current GT ID maps to different predicted IDs
         # in the current and in the previous frame / last seen frame
         # (ignore predicted IDs that are nan)
+        # (reIDs)
         for gt_id in gt_to_tracked_id_current_frame:
             pred_id_current_frame = gt_to_tracked_id_current_frame[gt_id]
             pred_id_previous_frame = gt_to_tracked_id_previous_frame.get(

--- a/crabs/tracker/evaluate_tracker.py
+++ b/crabs/tracker/evaluate_tracker.py
@@ -160,7 +160,7 @@ class TrackerEvaluate:
 
         return iou
 
-    def count_identity_switches(  # noqa: C901
+    def count_identity_switches(
         self,
         gt_to_tracked_id_previous_frame: Optional[dict[int, int]],
         gt_to_tracked_id_current_frame: dict[int, Union[int, float]],
@@ -353,8 +353,8 @@ class TrackerEvaluate:
         )
 
         # Compute MOTA
-        mota = (
-            1 - (missed_detections + false_positives + num_switches) / total_gt
+        mota = 1 - (
+            (missed_detections + false_positives + num_switches) / total_gt
         )
         return (
             mota,

--- a/crabs/tracker/evaluate_tracker.py
+++ b/crabs/tracker/evaluate_tracker.py
@@ -384,11 +384,16 @@ class TrackerEvaluate:
             "MOTA": [],
         }
 
-        for frame_number in sorted(ground_truth_dict.keys()):
+        for frame_index, frame_number in enumerate(
+            sorted(ground_truth_dict.keys())
+        ):
+            # assuming all frames have GT data
             gt_data_frame = ground_truth_dict[frame_number]
 
-            if frame_number < len(predicted_dict):
-                pred_data_frame = predicted_dict[frame_number]
+            if frame_number <= len(predicted_dict):
+                pred_data_frame = predicted_dict[
+                    frame_index
+                ]  # 0-based indexing
 
                 (
                     mota,
@@ -405,7 +410,9 @@ class TrackerEvaluate:
                     prev_frame_id_map,
                 )
                 mota_values.append(mota)
-                results["Frame Number"].append(frame_number)
+                results["Frame Number"].append(
+                    frame_number
+                )  # TODO: change to index!
                 results["Total Ground Truth"].append(total_gt)
                 results["True Positives"].append(true_positives)
                 results["Missed Detections"].append(missed_detections)

--- a/crabs/tracker/evaluate_tracker.py
+++ b/crabs/tracker/evaluate_tracker.py
@@ -18,6 +18,7 @@ class TrackerEvaluate:
 
     def __init__(
         self,
+        input_video_file_root: str,
         gt_dir: str,  # annotations_file
         predicted_boxes_dict: dict,
         iou_threshold: float,
@@ -30,6 +31,8 @@ class TrackerEvaluate:
 
         Parameters
         ----------
+        input_video_file_root : str
+            Filename without extension to the input video file.
         gt_dir : str
             Directory path of the ground truth CSV file.
         predicted_boxes_dict : dict
@@ -45,6 +48,7 @@ class TrackerEvaluate:
             Path to the directory where the tracking output will be saved.
 
         """
+        self.input_video_file_root = input_video_file_root
         self.gt_dir = gt_dir
         self.predicted_boxes_dict = predicted_boxes_dict
         self.iou_threshold = iou_threshold
@@ -420,7 +424,9 @@ class TrackerEvaluate:
                 results["Number of Switches"].append(num_switches)
                 results["MOTA"].append(mota)
 
-        save_tracking_mota_metrics(self.tracking_output_dir, results)
+        save_tracking_mota_metrics(
+            self.tracking_output_dir, self.input_video_file_root, results
+        )
 
         return mota_values
 

--- a/crabs/tracker/evaluate_tracker.py
+++ b/crabs/tracker/evaluate_tracker.py
@@ -56,7 +56,7 @@ class TrackerEvaluate:
         self.last_known_predicted_ids: dict = {}
 
     def get_ground_truth_data(self) -> dict[int, dict[str, Any]]:
-        """Fromat ground truth data as a dictionary with key frame number.
+        """Format ground truth data as a dictionary with key frame number.
 
         Returns
         -------
@@ -171,11 +171,12 @@ class TrackerEvaluate:
         ----------
         gt_to_tracked_id_previous_frame : Optional[dict[int, int]]
             A dictionary mapping ground truth IDs to predicted IDs from the
-            previous frame.
+            previous frame. A predicted ID can be NaN if the object was
+            a missed detection in the previous frame.
         gt_to_tracked_id_current_frame : dict[int, Union[int, float]]
             A dictionary mapping ground truth IDs to predicted IDs for the
-            current frame. The predicted IDs can be nan if the object was
-            missed in the current frame.
+            current frame. A predicted ID can be NaN if the object was
+            a missed detection in the current frame.
 
         Returns
         -------
@@ -408,22 +409,19 @@ class TrackerEvaluate:
         if len(ground_truth_dict) > len(predicted_dict):
             logging.warning(
                 "There are more frames in the ground truth than in the "
-                "predictions."
-                f"Only the first {len(predicted_dict)} frames will be "
-                "evaluated."
-                "To match the frames across ground truth and predictions, "
-                "we assume the first frame number in the ground truth is the "
-                "frame with index 0 in the predictions."
+                f"predictions. Only the first {len(predicted_dict)} frames "
+                "will be evaluated. To match the frames across ground truth "
+                "and predictions, we assume the first frame number in the "
+                "ground truth is the frame with index 0 in the predictions."
             )
         elif len(ground_truth_dict) < len(predicted_dict):
             logging.warning(
                 "There are more frames in the predictions than in the "
-                "ground truth."
-                f"Only the first {len(ground_truth_dict)} frames will be "
-                "evaluated."
-                "To match the frames across ground truth and predictions, "
-                "we assume the first frame number in the ground truth is the "
-                "frame with index 0 in the predictions."
+                f"ground truth. Only the first {len(ground_truth_dict)} "
+                "frames will be evaluated. To match the frames across ground "
+                "truth and predictions, we assume the first frame number in "
+                "the ground truth is the frame with index 0 in the "
+                "predictions."
             )
 
         # Loop through frame numbers in ground truth dict

--- a/crabs/tracker/evaluate_tracker.py
+++ b/crabs/tracker/evaluate_tracker.py
@@ -3,7 +3,7 @@
 import csv
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import numpy as np
 
@@ -163,7 +163,7 @@ class TrackerEvaluate:
     def count_identity_switches(  # noqa: C901
         self,
         gt_to_tracked_id_previous_frame: Optional[dict[int, int]],
-        gt_to_tracked_id_current_frame: dict[int, int | float],
+        gt_to_tracked_id_current_frame: dict[int, Union[int, float]],
     ) -> int:
         """Count the number of identity switches between two sets of IDs.
 
@@ -172,7 +172,7 @@ class TrackerEvaluate:
         gt_to_tracked_id_previous_frame : Optional[dict[int, int]]
             A dictionary mapping ground truth IDs to predicted IDs from the
             previous frame.
-        gt_to_tracked_id_current_frame : dict[int, int | float]
+        gt_to_tracked_id_current_frame : dict[int, Union[int, float]]
             A dictionary mapping ground truth IDs to predicted IDs for the
             current frame. The predicted IDs can be nan if the object was
             missed in the current frame.
@@ -271,7 +271,7 @@ class TrackerEvaluate:
         gt_data: dict[str, np.ndarray],
         pred_data: dict[str, np.ndarray],
         gt_to_tracked_id_previous_frame: Optional[dict[int, int]],
-    ) -> tuple[float, int, int, int, int, int, dict[int, int | float]]:
+    ) -> tuple[float, int, int, int, int, int, dict[int, Union[int, float]]]:
         """Evaluate MOTA (Multiple Object Tracking Accuracy).
 
         Parameters
@@ -293,7 +293,7 @@ class TrackerEvaluate:
         float
             The computed MOTA (Multi-Object Tracking Accuracy) score for the
             tracking performance.
-        dict[int, int]
+        dict[int, Union[int, float]]
             A dictionary mapping ground truth IDs to predicted IDs for the
             current frame.
 

--- a/crabs/tracker/track_video.py
+++ b/crabs/tracker/track_video.py
@@ -422,7 +422,9 @@ def tracking_parse_args(args):
         help=(
             "Location of CSV file containing ground truth annotations "
             "(optional). "
-            "If passed, the evaluation metrics for the tracker are computed."
+            "If passed, the evaluation metrics for the tracker are computed "
+            "and saved to a CSV file at "
+            "<output-dir>/<video-name>_tracking_metrics.csv."
         ),
     )
     parser.add_argument(

--- a/crabs/tracker/track_video.py
+++ b/crabs/tracker/track_video.py
@@ -316,6 +316,7 @@ class Tracking:
         # Evaluate tracker if ground truth is passed
         if self.args.annotations_file:
             evaluation = TrackerEvaluate(
+                self.input_video_file_root,
                 self.args.annotations_file,
                 tracked_bboxes_dict,
                 self.config["iou_threshold"],

--- a/crabs/tracker/track_video.py
+++ b/crabs/tracker/track_video.py
@@ -245,6 +245,9 @@ class Tracking:
         while input_video_object.isOpened():
             # Read frame
             ret, frame = input_video_object.read()
+
+            # If frame reading not successful, log either error
+            # or completion and break loop
             if not ret:
                 parse_video_frame_reading_error_and_log(
                     frame_idx, total_n_frames
@@ -300,7 +303,8 @@ class Tracking:
             )
             logging.info(f"Tracked video saved to {self.output_video_path}")
 
-        # Write frames if required
+        # Write frames if required (without bounding boxes)
+        # this is to support manual labelling of tracks
         # (it loops again thru frames)
         if self.args.save_frames:
             write_all_video_frames_as_images(
@@ -416,7 +420,7 @@ def tracking_parse_args(args):
         type=str,
         default=None,
         help=(
-            "Location of JSON file containing ground truth annotations "
+            "Location of CSV file containing ground truth annotations "
             "(optional). "
             "If passed, the evaluation metrics for the tracker are computed."
         ),

--- a/crabs/tracker/utils/tracking.py
+++ b/crabs/tracker/utils/tracking.py
@@ -82,9 +82,12 @@ def extract_bounding_box_info(row: list[str]) -> dict[str, Any]:
 
 def save_tracking_mota_metrics(
     tracking_output_dir: Path,
+    input_video_file_root: str,
     track_results: dict[str, Any],
 ) -> None:
     """Save tracking metrics to a CSV file."""
     track_df = pd.DataFrame(track_results)
-    output_filename = f"{tracking_output_dir}/tracking_metrics_output.csv"
+    output_filename = (
+        f"{tracking_output_dir}/{input_video_file_root}_tracking_metrics.csv"
+    )
     track_df.to_csv(output_filename, index=False)

--- a/crabs/tracker/utils/tracking.py
+++ b/crabs/tracker/utils/tracking.py
@@ -69,7 +69,13 @@ def extract_bounding_box_info(row: list[str]) -> dict[str, Any]:
     height = region_shape_attributes["height"]
     track_id = region_attributes["track"]
 
+    # Extract frame number from filename
+    # (it assumes frame number is the last part of the filename
+    # and is preceded by an underscore)
     frame_number = int(filename.split("_")[-1].split(".")[0])
+
+    # Return dictionary with frame number, bounding box coordinates,
+    # and track ID
     return {
         "frame_number": frame_number,
         "x": x,

--- a/tests/test_integration/test_inference.py
+++ b/tests/test_integration/test_inference.py
@@ -134,7 +134,9 @@ def test_detect_and_track_video(
 
     # check csv with tracking metrics exists
     tracking_metrics_csv = (
-        tmp_path / tracking_output_dir / "tracking_metrics_output.csv"
+        tmp_path
+        / tracking_output_dir
+        / f"{input_data_paths['video_root_name']}_tracking_metrics.csv"
     )
     assert (tracking_metrics_csv).exists()
 

--- a/tests/test_unit/test_evaluate_tracker.py
+++ b/tests/test_unit/test_evaluate_tracker.py
@@ -103,43 +103,55 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
             {1: 11, 2: 12, 3: 13, 4: 14},  # current_frame_id_map
             0,  # expected id switches
             id="object_continues_to_exist_correct",
-        ),  # correct
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: np.nan, 4: 14},
             0,
             id="object_continues_to_exist_missed_in_frame",
-        ),  # crab is missed detection in current frame
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: np.nan, 4: 14},
             {1: 11, 2: 12, 3: 13, 4: 14},
             0,
             id="object_continues_to_exist_missed_in_previous_frame",
-        ),  # crab is missed detection in previous frame
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 15, 4: 14},
             1,
-            id="object_continues_to_exist_re_ided_in_current_frame",
-        ),  # crab is re-IDed in current frame
+            id="object_continues_to_exist_re_id",
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14},
-            2,  # maybe this should be 2 for consistency with next one? ===================
-            id="object_continues_to_exist_swaps_id_with_disappearing_object",
-        ),  # crab swaps ID with a disappearing crab 
+            2,
+            id="object_continues_to_exist_re_id_and_swap_with_disappearing_object",
+        ),
+        pytest.param(
+            {1: 11, 2: 12, 3: 13},
+            {1: 11, 2: 12, 3: 99, 5: 13},
+            2,
+            id="object_continues_to_exist_re_id_and_swap_with_appearing_new_object",
+        ),
+        pytest.param(
+            {1: 11, 2: 12, 3: 13},
+            {1: 11, 2: 12, 3: 99, 4: 14},
+            1,
+            id="object_continues_to_exist_re_id_with_appearing_old_object",
+        ),  # old object = object that has historical data
         pytest.param(
             {1: 11, 2: 12, 3: 13},
             {1: 11, 2: 12, 3: 99, 4: 13},
-            2,
-            id="object_continues_to_exist_swaps_id_with_appearing_object",
-        ),  # crab swaps ID with an appearing crab
+            3,
+            id="object_continues_to_exist_re_id_and_swap_with_appearing_old_object_wrong",
+        ),  # old object = object that has historical data
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14, 4: 13},
-            4, # =====
-            id="object_continues_to_exist_swaps_id_with_continuing_object",
-        ),  # crab swaps ID with another crab that continues to exist
+            4,
+            id="two_objects_that_continue_to_exist_re_id_and_swap",
+        ),
         # ----- a crab (GT=4) disappears ---------
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
@@ -150,82 +162,77 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14},
-            2,  # maybe this should be 2 for consistency with next one? ==========
-            id="object_disappears_swaps_id_with_continuing_object",
-        ),  # crab disappears and another pre-existing one takes its ID --------
+            2,
+            id="object_disappears_swaps_id_with_re_ided_continuing_object",
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 13, 5: 14},
             1,
-            id="object_disappears_swaps_id_with_appearing_object",
-        ),  # crab disappears and an appearing one takes its ID
+            id="object_disappears_swaps_id_with_appearing_new_object",
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             {1: 11, 2: 12, 3: 13},
             0,
             id="object_disappears_missed_in_previous_frame",
-        ),  # crab disappears but was missed detection in frame f-1
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             {1: 11, 2: 12, 3: 13, 5: np.nan},
             0,
             id="object_disappears_missed_in_previous_frame_and_new_object_missed",
-        ),  # crab disappears but was missed detection in frame f-1,
-        # with a new missed crab in frame f
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             {1: 11, 2: 12, 3: np.nan},
             0,
             id="object_disappears_missed_in_previous_frame_and_continuing_object_missed",
-        ),  # crab disappears but was missed detection in frame f-1,
-        # and existing crab was missed in frame f
+        ),
         # ----- a crab (GT=3) disappears ---------
         pytest.param(
             {1: 11, 2: 12, 3: 13},
-            {1: 11, 2: 12, 4: 13},
+            {1: 11, 2: 12, 5: 13},
             1,
-            id="disappearing_object_swaps_id_with_appearing_object",
-        ),  # disappear crab swaps ID with an appearing crab
-        # ----- a crab (GT=4) appears ---------
+            id="disappearing_object_swaps_id_with_new_appearing_object",
+        ),
+        # ----- a crab (GT=5) appears without historical data ---------
         pytest.param(
             {1: 11, 2: 12, 3: 13},
-            {1: 11, 2: 12, 3: 13, 4: 14},
+            {1: 11, 2: 12, 3: 13, 5: 15},
             0,
-            id="object_appears_correct",
-        ),  # correct
+            id="new_object_appears_correct",
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13},
-            {1: 11, 2: 12, 3: 15, 4: 13},
+            {1: 11, 2: 12, 3: 15, 5: 13},
             2,
-            id="object_appears_swaps_id_with_continuing_object",  # ------
-        ),  # crab that appears gets ID of a pre-existing crab
-        # and crab that continues is re-ID
+            id="new_object_appears_swaps_id_with_re_ided_continuing_object",
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13},
-            {1: 11, 2: 12, 4: 13},
+            {1: 11, 2: 12, 5: 13},
             1,
-            id="object_appears_swaps_id_with_disappearing_object",
-        ),  # crab that appears gets ID of a crab that disappears
+            id="new_object_appears_swaps_id_with_disappearing_object",
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: 13},
-            {1: 11, 2: 12, 3: 13, 4: np.nan},
-            0,
-            id="object_appears_missed_in_current_frame",
-        ),  # missed detection in current frame
-        pytest.param(
             {1: 11, 2: 12, 3: 13, 5: np.nan},
-            {1: 11, 2: 12, 3: 13, 4: np.nan},
             0,
-            id="object_appears_missed_in_current_frame_and_disappearing_object_missed_in_previous_frame",
-        ),  # crab that appears is missed detection in current frame,
-        # and another missed detection in previous frame disappears
+            id="new_object_appears_missed_in_current_frame",
+        ),
+        pytest.param(
+            {1: 11, 2: 12, 3: 13, 4: np.nan},
+            {1: 11, 2: 12, 3: 13, 5: np.nan},
+            0,
+            id="new_object_appears_missed_in_current_frame_and_disappearing_object_missed_in_previous_frame",
+        ),
         pytest.param(
             {1: 11, 2: 12, 3: np.nan},
-            {1: 11, 2: 12, 3: 13, 4: np.nan},
+            {1: 11, 2: 12, 3: 13, 5: np.nan},
             0,
-            id="object_appears_missed_in_current_frame_and_continuing_object_missed_in_previous_frame",
-        ),  # crab that appears is missed detection in current frame,
-        # and a pre-existing crab is missed detection in previous frame
+            id="new_object_appears_missed_in_current_frame_and_continuing_object_missed_in_previous_frame",
+        ),
         # ----------
         # Test consistency with last predicted ID if a crab (GT=3)
         # that continues to exist is not detected for a few frames (>= 1)
@@ -235,16 +242,13 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
             {1: 11, 2: 12, 3: 13},
             0,
             id="object_missed_in_previous_frame_consistent_with_historical",
-        ),  # crab that continues to exist, and the current predicted ID is
-        # consistent with last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
+        ),  # last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
         pytest.param(
             {1: 11, 2: 12, 3: np.nan},
             {1: 11, 2: 12, 3: 14},
             1,
             id="object_missed_in_previous_frame_not_consistent_with_historical",
-        ),  # crab that continues to exist, and the current predicted ID
-        # is NOT consistent with the
-        # last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
+        ),  # last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
         # ----------
         # Test consistency with last predicted ID if a crab (GT=3)
         # re-appears after a few frames (>= 1)
@@ -254,22 +258,18 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
             {1: 11, 2: 12, 3: 13},
             0,
             id="object_reappears_consistent_with_historical",
-        ),  # crab whose GT ID is in last_known_predicted_ids, appears
-        # in the current frame, and the current predicted ID is consistent
-        # with last_known_predicted_ids
+        ),  # last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
         pytest.param(
             {1: 11, 2: 12},
             {1: 11, 2: 12, 3: 14},
             1,
             id="object_reappears_not_consistent_with_historical",
-        ),  # crab whose GT ID is in last_known_predicted_ids, appears
-        # in the current frame, and the current predicted ID is NOT consistent
-        # with last_known_predicted_ids
+        ),  # last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
         pytest.param(
             {1: 11, 2: 12, 3: 13, 5: np.nan},
             {1: 11, 2: 12, 3: np.nan, 5: 13},
             1,
-            id="object_not_in_historical_takes_id_of_missed_object",
+            id="new_object_swaps_id_with_missed_continuing_object",
         ),
     ],
 )
@@ -361,7 +361,7 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 12, 13]),
             },
-            {1: 11, 12: 2, 3: np.nan},
+            {1: 11, 12: 2, 3: np.nan},  # prev_frame_id_map
             [1.0, 3, 0, 0, 0],  # MOTA, TP, MD, FP, IDswitches
         ),
         # ID switch
@@ -386,7 +386,7 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 12, 14]),
             },
-            {1: 11, 2: 12, 3: 13},
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
             [2 / 3, 3, 0, 0, 1],  # MOTA, TP, MD, FP, IDswitches
         ),
         # missed detection
@@ -407,8 +407,8 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 12]),
             },
-            {1: 11, 2: 12, 3: 13},
-            [2 / 3, 2, 1, 0, 0],
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
+            [2 / 3, 2, 1, 0, 0],  # MOTA, TP, MD, FP, IDswitches
         ),
         # false positive
         (
@@ -433,8 +433,8 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 12, 13, 14]),
             },
-            {1: 11, 2: 12, 3: 13},
-            [2 / 3, 3, 0, 1, 0],
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
+            [2 / 3, 3, 0, 1, 0],  # MOTA, TP, MD, FP, IDswitches
         ),
         # low IOU and ID switch
         (
@@ -458,8 +458,8 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 12, 14]),
             },
-            {1: 11, 2: 12, 3: 13},
-            [0, 2, 1, 1, 1],
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
+            [0, 2, 1, 1, 1],  # MOTA, TP, MD, FP, IDswitches
         ),
         # low IOU and ID switch on same box
         (
@@ -483,8 +483,8 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 14, 13]),
             },
-            {1: 11, 2: 12, 3: 13},
-            [1 / 3, 2, 1, 1, 0],
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
+            [1 / 3, 2, 1, 1, 0],  # MOTA, TP, MD, FP, IDswitches
         ),
         # current tracked id = prev tracked id, but prev_gt_id != current gt id
         (
@@ -508,8 +508,8 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 12, 13]),
             },
-            {1: 11, 2: 12, 3: 13},
-            [2 / 3, 3, 0, 0, 1],
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
+            [2 / 3, 3, 0, 0, 1],  # MOTA, TP, MD, FP, IDswitches
         ),
         # ID swapped
         (
@@ -533,8 +533,8 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 13, 12]),
             },
-            {1: 11, 2: 12, 3: 13},
-            [1 / 3, 3, 0, 0, 2],
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
+            [1 - (4 / 3), 3, 0, 0, 4],  # MOTA, TP, MD, FP, IDswitches
         ),
     ],
 )
@@ -556,7 +556,6 @@ def test_compute_mota_one_frame(
     ) = tracker_evaluate_interface.compute_mota_one_frame(
         gt_data,
         pred_data,
-        # 0.1,
         prev_frame_id_map,
     )
     assert mota == pytest.approx(expected_output[0])

--- a/tests/test_unit/test_evaluate_tracker.py
+++ b/tests/test_unit/test_evaluate_tracker.py
@@ -11,7 +11,7 @@ def tracker_evaluate_interface():
     annotations_file_csv = Path(__file__).parents[1] / "data" / "gt_test.csv"
     return TrackerEvaluate(
         input_video_file_root="/path/to/video.mp4",
-        gt_dir=annotations_file_csv,
+        annotations_file=annotations_file_csv,
         predicted_boxes_dict={},
         iou_threshold=0.1,
         tracking_output_dir="/path/output",
@@ -93,128 +93,155 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
 @pytest.mark.parametrize(
     "prev_frame_id_map, current_frame_id_map, expected_output",
     [
-        (None, {1: 11, 2: 12, 3: 13, 4: 14}, 0),  # no previous frame
+        # --------- no previous frame ---------
+        pytest.param(
+            None, {1: 11, 2: 12, 3: 13, 4: 14}, 0, id="no_previous_frame"
+        ),
         # ----- a crab (GT=3) that continues to exist ---------
-        (
-            {1: 11, 2: 12, 3: 13, 4: 14},
-            {1: 11, 2: 12, 3: 13, 4: 14},
-            0,
+        pytest.param(
+            {1: 11, 2: 12, 3: 13, 4: 14},  # prev_frame_id_map
+            {1: 11, 2: 12, 3: 13, 4: 14},  # current_frame_id_map
+            0,  # expected id switches
+            id="object_continues_to_exist_correct",
         ),  # correct
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: np.nan, 4: 14},
             0,
+            id="object_continues_to_exist_missed_in_frame",
         ),  # crab is missed detection in current frame
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: np.nan, 4: 14},
             {1: 11, 2: 12, 3: 13, 4: 14},
             0,
+            id="object_continues_to_exist_missed_in_previous_frame",
         ),  # crab is missed detection in previous frame
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 15, 4: 14},
             1,
+            id="object_continues_to_exist_re_ided_in_current_frame",
         ),  # crab is re-IDed in current frame
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14},
-            1,
-        ),  # crab swaps ID with a disappearing crab
-        (
-            {1: 11, 2: 12, 3: 13},
-            {1: 11, 2: 12, 4: 13},
-            1,
-        ),  # disappear crab swaps ID with an appearing crab
-        (
+            1,  # maybe this should be 2 for consistency with next one?
+            id="object_continues_to_exist_swaps_id_with_disappearing_object",
+        ),  # crab swaps ID with a disappearing crab -------
+        pytest.param(
             {1: 11, 2: 12, 3: 13},
             {1: 11, 2: 12, 3: 99, 4: 13},
             2,
+            id="object_continues_to_exist_swaps_id_with_appearing_object",
         ),  # crab swaps ID with an appearing crab
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14, 4: 13},
             2,
+            id="object_continues_to_exist_swaps_id_with_continuing_object",
         ),  # crab swaps ID with another crab that continues to exist
         # ----- a crab (GT=4) disappears ---------
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 13},
             0,
+            id="object_disappears_correct",
         ),  # correct
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14},
-            1,
-        ),  # crab disappears and another pre-existing one takes its ID
-        (
+            1, # maybe this should be 2 for consistency with next one?
+            id="object_disappears_swaps_id_with_continuing_object",
+        ),  # crab disappears and another pre-existing one takes its ID --------
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 13, 5: 14},
             1,
+            id="object_disappears_swaps_id_with_appearing_object",
         ),  # crab disappears and an appearing one takes its ID
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             {1: 11, 2: 12, 3: 13},
             0,
+            id="object_disappears_missed_in_previous_frame",
         ),  # crab disappears but was missed detection in frame f-1
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             {1: 11, 2: 12, 3: 13, 5: np.nan},
             0,
+            id="object_disappears_missed_in_previous_frame_and_new_object_missed",
         ),  # crab disappears but was missed detection in frame f-1,
         # with a new missed crab in frame f
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             {1: 11, 2: 12, 3: np.nan},
             0,
+            id="object_disappears_missed_in_previous_frame_and_continuing_object_missed",
         ),  # crab disappears but was missed detection in frame f-1,
         # and existing crab was missed in frame f
-        # ----- a crab (GT=4) appears ---------
-        (
-            {1: 11, 2: 12, 3: 13},
-            {1: 11, 2: 12, 3: 13, 4: 14},
-            0,
-        ),  # correct
-        (
-            {1: 11, 2: 12, 3: 14},
-            {1: 11, 2: 12, 3: 13, 4: 14},
-            2,
-        ),  # crab that appears gets ID of a pre-existing crab
-        (
+        # ----- a crab (GT=3) disappears ---------
+               pytest.param(
             {1: 11, 2: 12, 3: 13},
             {1: 11, 2: 12, 4: 13},
             1,
+            id="disappearing_object_swaps_id_with_appearing_object",
+        ),  # disappear crab swaps ID with an appearing crab
+        # ----- a crab (GT=4) appears ---------
+        pytest.param(
+            {1: 11, 2: 12, 3: 13},
+            {1: 11, 2: 12, 3: 13, 4: 14},
+            0,
+            id="object_appears_correct",
+        ),  # correct
+        pytest.param(
+            {1: 11, 2: 12, 3: 13},
+            {1: 11, 2: 12, 3: 15, 4: 13},
+            2,
+            id="object_appears_swaps_id_with_continuing_object",  #------
+        ),  # crab that appears gets ID of a pre-existing crab
+        # and crab that continues is re-ID
+        pytest.param(
+            {1: 11, 2: 12, 3: 13},
+            {1: 11, 2: 12, 4: 13},
+            1,
+            id="object_appears_swaps_id_with_disappearing_object",
         ),  # crab that appears gets ID of a crab that disappears
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13},
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             0,
+            id="object_appears_missed_in_current_frame",
         ),  # missed detection in current frame
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 5: np.nan},
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             0,
+            id="object_appears_missed_in_current_frame_and_disappearing_object_missed_in_previous_frame",
         ),  # crab that appears is missed detection in current frame,
         # and another missed detection in previous frame disappears
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: np.nan},
             {1: 11, 2: 12, 3: 13, 4: np.nan},
             0,
+            id="object_appears_missed_in_current_frame_and_continuing_object_missed_in_previous_frame",
         ),  # crab that appears is missed detection in current frame,
         # and a pre-existing crab is missed detection in previous frame
         # ----------
         # Test consistency with last predicted ID if a crab (GT=3)
         # that continues to exist is not detected for a few frames (>= 1)
         # ------------
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: np.nan},
             {1: 11, 2: 12, 3: 13},
             0,
+            id="object_missed_in_previous_frame_consistent_with_historical",
         ),  # crab that continues to exist, and the current predicted ID is
         # consistent with last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
-        (
+        pytest.param(
             {1: 11, 2: 12, 3: np.nan},
             {1: 11, 2: 12, 3: 14},
             1,
+            id="object_missed_in_previous_frame_not_consistent_with_historical",
         ),  # crab that continues to exist, and the current predicted ID
         # is NOT consistent with the
         # last_known_predicted_ids={1: 11, 2: 12, 3: 13, 4: 14}
@@ -222,20 +249,28 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
         # Test consistency with last predicted ID if a crab (GT=3)
         # re-appears after a few frames (>= 1)
         # ------------
-        (
+        pytest.param(
             {1: 11, 2: 12},
             {1: 11, 2: 12, 3: 13},
             0,
+            id="object_reappears_consistent_with_historical",
         ),  # crab whose GT ID is in last_known_predicted_ids, appears
         # in the current frame, and the current predicted ID is consistent
         # with last_known_predicted_ids
-        (
+        pytest.param(
             {1: 11, 2: 12},
             {1: 11, 2: 12, 3: 14},
             1,
+            id="object_reappears_not_consistent_with_historical",
         ),  # crab whose GT ID is in last_known_predicted_ids, appears
         # in the current frame, and the current predicted ID is NOT consistent
         # with last_known_predicted_ids
+         pytest.param(
+            {1: 11, 2: 12, 3: 13, 5: np.nan},
+            {1: 11, 2: 12, 3: np.nan, 5: 13},
+            1,
+            id="object_not_in_historical_takes_id_of_missed_object",
+        ),  
     ],
 )
 def test_count_identity_switches(
@@ -302,8 +337,8 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 ),
                 "ids": np.array([11, 12, 13]),
             },
-            {1: 11, 2: 12, 3: 13},
-            [1.0, 3, 0, 0, 0],
+            {1: 11, 2: 12, 3: 13},  # prev_frame_id_map
+            [1.0, 3, 0, 0, 0],  # MOTA, TP, MD, FP, IDswitches
         ),
         (
             {
@@ -327,7 +362,7 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 "ids": np.array([11, 12, 13]),
             },
             {1: 11, 12: 2, 3: np.nan},
-            [1.0, 3, 0, 0, 0],
+            [1.0, 3, 0, 0, 0],  # MOTA, TP, MD, FP, IDswitches
         ),
         # ID switch
         (
@@ -352,7 +387,7 @@ def test_calculate_iou(box1, box2, expected_iou, tracker_evaluate_interface):
                 "ids": np.array([11, 12, 14]),
             },
             {1: 11, 2: 12, 3: 13},
-            [2 / 3, 3, 0, 0, 1],
+            [2 / 3, 3, 0, 0, 1],  # MOTA, TP, MD, FP, IDswitches
         ),
         # missed detection
         (
@@ -521,7 +556,7 @@ def test_compute_mota_one_frame(
     ) = tracker_evaluate_interface.compute_mota_one_frame(
         gt_data,
         pred_data,
-        0.1,  # iou_threshold
+        # 0.1,
         prev_frame_id_map,
     )
     assert mota == pytest.approx(expected_output[0])

--- a/tests/test_unit/test_evaluate_tracker.py
+++ b/tests/test_unit/test_evaluate_tracker.py
@@ -125,9 +125,9 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14},
-            1,  # maybe this should be 2 for consistency with next one?
+            2,  # maybe this should be 2 for consistency with next one? ===================
             id="object_continues_to_exist_swaps_id_with_disappearing_object",
-        ),  # crab swaps ID with a disappearing crab -------
+        ),  # crab swaps ID with a disappearing crab 
         pytest.param(
             {1: 11, 2: 12, 3: 13},
             {1: 11, 2: 12, 3: 99, 4: 13},
@@ -137,7 +137,7 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14, 4: 13},
-            2,
+            4, # =====
             id="object_continues_to_exist_swaps_id_with_continuing_object",
         ),  # crab swaps ID with another crab that continues to exist
         # ----- a crab (GT=4) disappears ---------
@@ -150,7 +150,7 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
         pytest.param(
             {1: 11, 2: 12, 3: 13, 4: 14},
             {1: 11, 2: 12, 3: 14},
-            1, # maybe this should be 2 for consistency with next one?
+            2,  # maybe this should be 2 for consistency with next one? ==========
             id="object_disappears_swaps_id_with_continuing_object",
         ),  # crab disappears and another pre-existing one takes its ID --------
         pytest.param(
@@ -180,7 +180,7 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
         ),  # crab disappears but was missed detection in frame f-1,
         # and existing crab was missed in frame f
         # ----- a crab (GT=3) disappears ---------
-               pytest.param(
+        pytest.param(
             {1: 11, 2: 12, 3: 13},
             {1: 11, 2: 12, 4: 13},
             1,
@@ -197,7 +197,7 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
             {1: 11, 2: 12, 3: 13},
             {1: 11, 2: 12, 3: 15, 4: 13},
             2,
-            id="object_appears_swaps_id_with_continuing_object",  #------
+            id="object_appears_swaps_id_with_continuing_object",  # ------
         ),  # crab that appears gets ID of a pre-existing crab
         # and crab that continues is re-ID
         pytest.param(
@@ -265,12 +265,12 @@ def test_ground_truth_data_values(tracker_evaluate_interface):
         ),  # crab whose GT ID is in last_known_predicted_ids, appears
         # in the current frame, and the current predicted ID is NOT consistent
         # with last_known_predicted_ids
-         pytest.param(
+        pytest.param(
             {1: 11, 2: 12, 3: 13, 5: np.nan},
             {1: 11, 2: 12, 3: np.nan, 5: 13},
             1,
             id="object_not_in_historical_takes_id_of_missed_object",
-        ),  
+        ),
     ],
 )
 def test_count_identity_switches(

--- a/tests/test_unit/test_evaluate_tracker.py
+++ b/tests/test_unit/test_evaluate_tracker.py
@@ -10,7 +10,8 @@ from crabs.tracker.evaluate_tracker import TrackerEvaluate
 def tracker_evaluate_interface():
     annotations_file_csv = Path(__file__).parents[1] / "data" / "gt_test.csv"
     return TrackerEvaluate(
-        annotations_file_csv,
+        input_video_file_root="/path/to/video.mp4",
+        gt_dir=annotations_file_csv,
         predicted_boxes_dict={},
         iou_threshold=0.1,
         tracking_output_dir="/path/output",


### PR DESCRIPTION
## Description

This PR:

- Changes the name of the output csv file with the tracking metrics (MOTA, FP, TP, missed, ID switches per frame) to include the name of the input video.
    - adapt tests accordingly 
- Changes the name of the input argument with the ground truth annotations in the `TrackerEvaluate` constructor
- Fixes mismatch between indexing ground truth and predictions when evaluating the tracking over all frames
	- the ground truth was indexed by frame number (extracted from filename) while the predictions were indexed by frame index (0-based). 
- Removes `iou_threshold` as input argument to `compute_mota_one_frame` 
    - the IoU threshold is defined in the contructor 
- Redefines ID switches for simplicity and consistency
    - there were inconsistencies in how we counted ID swaps if a crab appeared or disappeared. 
	- I re-defined the total number of ID switches per frame as the sum of ID swaps (same predicted IDs associated to different gt IDs in current and previous frame) and reIDs (same gt IDs mapped to different predicted IDs in current and previous frame). 
	- we compare the current predicted ID to the last seen predicted ID for the same ground truth ID (if it was missed or not present in the immediately previous frame)
	- I adapted the tests for counting ID switching and added an extra case
	- I adapted the README for tracking to explain these changes
- Adds test for `evaluate_tracking `
    - tracking output is compared directly to the expected values (i.e., true positives, Missed detections, false negatives, id switches and MOTA per frame must match)


## Checklist:
- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
