### PR TITLE
Add flag to omit timestamp in output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To track crabs in a new video, using a trained detector and a tracker, run the f
 detect-and-track-video --trained_model_path <path-to-ckpt-file> --video_path <path-to-input-video>
 ```
 
-This will produce a `tracking_output_<timestamp>` directory with the output from tracking under the current working directory.
+This will produce a `tracking_output_<timestamp>` directory with the output from tracking under the current working directory. To avoid adding the `<timestamp>` suffix to the directory name, add the `--output_dir_no_timestamp` flag to the command. To see the full list of possible arguments to the `evaluate-detector` command, run it with the `--help` flag.
 
 The tracking output consists of:
 - a .csv file named `<video-name>_tracks.csv`, with the tracked bounding boxes data;
@@ -152,8 +152,6 @@ Note that when using `--save_frames`, the frames of the video are saved as-is, w
 If a file with ground-truth annotations is passed to the command (with the `--annotations_file` flag), the MOTA metric for evaluating tracking is computed and printed to screen.
 
 <!-- When used in combination with the `--save_video` flag, the tracked video will contain predicted bounding boxes in red, and ground-truth bounding boxes in green. -- PR 216-->
-
-To see the full list of possible arguments to the `evaluate-detector` command, run it with the `--help` flag.
 
 ## Task-specific guides
 For further information on specific tasks, such as launching a training job or evaluating a set of models in the HPC cluster, please see [our guides](guides).

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To track crabs in a new video, using a trained detector and a tracker, run the f
 detect-and-track-video --trained_model_path <path-to-ckpt-file> --video_path <path-to-input-video>
 ```
 
-This will produce a `tracking_output_<timestamp>` directory with the output from tracking under the current working directory. To avoid adding the `<timestamp>` suffix to the directory name, add the `--output_dir_no_timestamp` flag to the command. To see the full list of possible arguments to the `evaluate-detector` command, run it with the `--help` flag.
+This will produce a `tracking_output_<timestamp>` directory with the output from tracking under the current working directory. To avoid adding the `<timestamp>` suffix to the directory name, run the command with the `--output_dir_no_timestamp` flag. To see the full list of possible arguments to the `detect-and-track-video` command, run it with the `--help` flag.
 
 The tracking output consists of:
 - a .csv file named `<video-name>_tracks.csv`, with the tracked bounding boxes data;

--- a/crabs/tracker/track_video.py
+++ b/crabs/tracker/track_video.py
@@ -92,15 +92,19 @@ class Tracking:
 
         This method:
         - creates a timestamped directory to store the tracking output.
+          Optionally the timestamp can be omitted.
         - sets the name of the output csv file for the tracked bounding boxes.
         - sets up the output video path if required.
         - sets up the frames subdirectory path if required.
         """
         # Create output directory
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.tracking_output_dir = Path(
-            self.tracking_output_dir_root + f"_{timestamp}"
-        )
+        if self.args.output_dir_no_timestamp:
+            self.tracking_output_dir = Path(self.tracking_output_dir_root)
+        else:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            self.tracking_output_dir = Path(
+                self.tracking_output_dir_root + f"_{timestamp}"
+            )
         self.tracking_output_dir.mkdir(parents=True, exist_ok=True)
 
         # Set name of output csv file
@@ -366,13 +370,21 @@ def tracking_parse_args(args):
         default="tracking_output",
         help=(
             "Root name of the directory to save the tracking output. "
-            "The name of the output directory is appended with a timestamp. "
+            "By default, the name of the output directory is appended with "
+            "a timestamp. "
             "The tracking output consist of a .csv. file named "
             "<video-name>_tracks.csv with the tracked bounding boxes. "
             "Optionally, it can include a video file named "
             "<video-name>_tracks.mp4, and all frames from the video "
             "under a <video-name>_frames subdirectory. "
-            "Default: ./tracking_output_<timestamp>. "
+            "Default: tracking_output_<timestamp>. "
+        ),
+    )
+    parser.add_argument(
+        "--output_dir_no_timestamp",
+        action="store_true",
+        help=(
+            "Flag to disable appending a timestamp to the output directory. "
         ),
     )
     parser.add_argument(

--- a/crabs/tracker/track_video.py
+++ b/crabs/tracker/track_video.py
@@ -371,7 +371,8 @@ def tracking_parse_args(args):
         help=(
             "Root name of the directory to save the tracking output. "
             "By default, the name of the output directory is appended with "
-            "a timestamp. "
+            "a timestamp. The timestamp can be omitted with the "
+            "--output_dir_no_timestamp flag. "
             "The tracking output consist of a .csv. file named "
             "<video-name>_tracks.csv with the tracked bounding boxes. "
             "Optionally, it can include a video file named "
@@ -384,7 +385,8 @@ def tracking_parse_args(args):
         "--output_dir_no_timestamp",
         action="store_true",
         help=(
-            "Flag to disable appending a timestamp to the output directory. "
+            "Flag to disable appending a timestamp to the output "
+            "directory name. "
         ),
     )
     parser.add_argument(

--- a/crabs/tracker/track_video.py
+++ b/crabs/tracker/track_video.py
@@ -69,7 +69,7 @@ class Tracking:
 
         # input video data
         self.input_video_path = args.video_path
-        self.input_video_file_root = f"{Path(self.input_video_path).stem}"
+        self.input_video_file_root = Path(self.input_video_path).stem
 
         # tracking output directory root name
         self.tracking_output_dir_root = args.output_dir

--- a/tests/test_unit/test_track_video.py
+++ b/tests/test_unit/test_track_video.py
@@ -10,12 +10,9 @@ from crabs.tracker.track_video import Tracking
 
 
 @pytest.fixture()
-def create_mock_args():
-    """Return a factory of mock arguments for Tracking class.
-
-    The factory returns a Namespace object with mock arguments for Tracking
-    class. When called, the factory also creates a temporary file with the
-    specified tracking config, whose path gets added to the Namespace object.
+def create_tracking_config_file():
+    """Return a factory to create a tracking config file under a Pytest
+    temporary directory.
     """
 
     def _create_tracking_config_file(
@@ -33,27 +30,28 @@ def create_mock_args():
             )
         return path_to_config
 
+    return _create_tracking_config_file
+
+
+@pytest.fixture()
+def create_mock_args():
+    """Return a factory of mock arguments for Tracking class.
+
+    The factory returns a Namespace object with mock arguments for Tracking
+    class. When called, the factory also creates a temporary file with the
+    specified tracking config, whose path gets added to the Namespace object.
+    """
+
     def _create_mock_args(
-        tracking_config: dict,
-        tmp_path: Path,
+        args_dict: dict,
+        # tracking_config: dict,
+        # tmp_path: Path,
     ) -> Namespace:
         """Return a Namespace object with mock arguments for Tracking class,
         given a tracking config dictionary and a factory to create a tracking
         config files.
         """
-        return Namespace(
-            video_path="/path/to/video.mp4",
-            trained_model_path="path/to/model.ckpt",
-            config_file=_create_tracking_config_file(
-                tracking_config, tmp_path
-            ),
-            accelerator="gpu",
-            output_dir="tracking_output",  # default
-            output_dir_no_timestamp=None,
-            annotations_file=None,
-            save_video=None,
-            save_frames=None,
-        )
+        return Namespace(**args_dict)
 
     return _create_mock_args
 
@@ -147,20 +145,66 @@ def test_tracking_constructor(
     assert tracker.accelerator == "cuda"
 
 
-def test_prep_outputs(create_mock_args, mock_mkdir, tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "output_dir",
+    [
+        "tracking_output",  # default
+        "output",
+    ],
+)
+@pytest.mark.parametrize(
+    "output_dir_no_timestamp",
+    [
+        False,
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "save_video",
+    [
+        False,
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "save_frames",
+    [
+        False,
+        True,
+    ],
+)
+def test_prep_outputs(
+    output_dir,
+    output_dir_no_timestamp,
+    save_video,
+    save_frames,
+    create_mock_args,
+    create_tracking_config_file,
+    mock_mkdir,
+    tmp_path,
+    monkeypatch,
+):
     """Test attributes related to outputs are correctly defined.
 
-    Check paths are defined and output directory and
-    optionally frames subdirectory are created.
+    Checks paths for required outputs are defined, and that the output
+    directory and (optional) frames subdirectory are created. The
+    directories are created under a temporary directory created by pytest.
 
     """
     # Create mock arguments for the constructor
-    tracking_config = {
-        "max_age": 10,
-        "min_hits": 3,
-        "iou_threshold": 0.1,
-    }
-    mock_args = create_mock_args(tracking_config, tmp_path)
+    mock_args = create_mock_args(
+        {
+            "video_path": "/path/to/video.mp4",
+            "trained_model_path": "path/to/model.ckpt",
+            "config_file": create_tracking_config_file({}, tmp_path),
+            "accelerator": "gpu",
+            "output_dir": output_dir,
+            "output_dir_no_timestamp": output_dir_no_timestamp,
+            "annotations_file": None,
+            "save_video": save_video,
+            "save_frames": save_frames,
+        }
+    )
 
     # mock getting mlflow parameters from checkpoint
     monkeypatch.setattr(
@@ -182,21 +226,16 @@ def test_prep_outputs(create_mock_args, mock_mkdir, tmp_path, monkeypatch):
     # under a Pytest temporary directory
     tracker = Tracking(mock_args)
 
-    # assert output directory is created
-    # can I mock current working directory?
-    # mock mkdir to create everything under a pytest tempdir?
-    # - with default name
-    # - with required name
-    # - with or without timestamp
-    # if mock_args.output_dir_no_timestamp: -----
-
     # check name of output directory
     if mock_args.output_dir:
         output_dir_root = mock_args.output_dir
     else:
-        output_dir_root = "tracking_output"
-    output_dir_regexp = re.compile(rf"{output_dir_root}_\d{{8}}_\d{{6}}$")
-    assert output_dir_regexp.match(tracker.tracking_output_dir.stem)
+        output_dir_root = "tracking_output"  # default
+    if mock_args.output_dir_no_timestamp:
+        assert tracker.tracking_output_dir.stem == output_dir_root
+    else:
+        output_dir_regexp = re.compile(rf"{output_dir_root}_\d{{8}}_\d{{6}}$")
+        assert output_dir_regexp.match(tracker.tracking_output_dir.stem)
 
     # check path to csv file with detections is defined
     assert tracker.csv_file_path == str(
@@ -214,13 +253,14 @@ def test_prep_outputs(create_mock_args, mock_mkdir, tmp_path, monkeypatch):
     # check output directory is created
     # (under pytest temporary directory, which
     # acts as if current working directory via mkdir mocking)
-    full_path_tracking_output_dir = tmp_path / tracker.tracking_output_dir
-    assert full_path_tracking_output_dir.exists()
+    assert (tmp_path / tracker.tracking_output_dir).exists()
 
     # check path to frames subdirectory is defined and created
     if mock_args.save_frames:
-        assert tracker.frames_subdir == str(
-            full_path_tracking_output_dir
+        # assert name
+        assert tracker.frames_subdir == (
+            tracker.tracking_output_dir
             / f"{tracker.input_video_file_root}_frames"
         )
-        assert tracker.frames_subdir.exists()
+        # assert creation
+        assert (tmp_path / tracker.frames_subdir).exists()

--- a/tests/test_unit/test_track_video.py
+++ b/tests/test_unit/test_track_video.py
@@ -11,15 +11,17 @@ from crabs.tracker.track_video import Tracking
 
 @pytest.fixture()
 def create_tracking_config_file():
-    """Return a factory to create a tracking config file under a Pytest
-    temporary directory.
+    """Return a factory of tracking config files.
+
+    The file is saved under a Pytest temporary directory and
+    its path is returned.
     """
 
     def _create_tracking_config_file(
         tracking_config: dict, tmp_path: Path
     ) -> Path:
-        """Return the path to a tracking config file under a Pytest temporary
-        directory.
+        """Create a tracking config file under a
+        Pytest temporary directory and return its path.
         """
         path_to_config = Path(tmp_path) / "tracking_config.yaml"
 
@@ -35,19 +37,13 @@ def create_tracking_config_file():
 
 @pytest.fixture()
 def create_mock_args():
-    """Return a factory of mock arguments for Tracking class.
-
-    The factory returns a Namespace object with mock arguments for Tracking
-    class. When called, the factory also creates a temporary file with the
-    specified tracking config, whose path gets added to the Namespace object.
-    """
+    """Return a factory of mock input arguments for the Tracking class."""
 
     def _create_mock_args(
         args_dict: dict,
     ) -> Namespace:
-        """Return a Namespace object with mock arguments for Tracking class,
-        given a tracking config dictionary and a factory to create a tracking
-        config files.
+        """Create a Namespace object with mock arguments for the Tracking class
+        for a given tracking config dictionary.
         """
         return Namespace(**args_dict)
 
@@ -59,8 +55,8 @@ def mock_mkdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Monkeypatch pathlib.Path.mkdir().
 
     Instead of creating the directory at the path specified,
-    mock the method to create the directory under a temporary
-    directory created by pytest.
+    mock the mkdir method to create the directory under
+    Pytest's temporary directory.
 
     Parameters
     ----------
@@ -86,7 +82,7 @@ def test_tracking_constructor(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test constructor for Tracking class."""
+    """Test the constructor for the Tracking class."""
     # Create mock arguments for the constructor
     tracking_config = {
         "max_age": 10,
@@ -135,7 +131,7 @@ def test_tracking_constructor(
     # instantiate the Tracking class
     tracker = Tracking(mock_args)
 
-    # check attributes from constructor are correctly defined
+    # check attributes from constructor are correctly set
     assert tracker.args == mock_args
     assert tracker.config_file == mock_args.config_file
     assert tracker.config == tracking_config
@@ -195,12 +191,11 @@ def test_prep_outputs(
     tmp_path,
     monkeypatch,
 ):
-    """Test attributes related to outputs are correctly defined.
+    """Test prep_outputs method of the Tracking class.
 
-    Checks paths for required outputs are defined, and that the output
-    directory and (optional) frames subdirectory are created. The
-    directories are created under a temporary directory created by pytest.
-
+    Checks the paths for the required outputs are defined, and that the output
+    directory and the (optional) frames subdirectory are created. Any created
+    directories are placed under a temporary directory created by Pytest.
     """
     # Create mock arguments for the constructor
     mock_args = create_mock_args(
@@ -232,7 +227,8 @@ def test_prep_outputs(
         lambda **kwargs: {},
     )
 
-    # Instantiate tracking interface - includes prep_outputs step
+    # Instantiate the tracking interface class
+    # The constructor includes running the .prep_outputs method
     # Note: mkdir is patched via `mock_mkdir` to create any output
     # directories under a Pytest temporary directory
     tracker = Tracking(mock_args)


### PR DESCRIPTION
## Description

**What is this PR?**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
At the moment each run of the command `detect-and-track` will generate a timestamped directory for the outputs (csv with detections and optionally frames and tracked video).

If we use a bash script to run this command over a set of videos (as we do in the cluster, see #251), we create one timestamped output directory per video, which is inconvenient and confusing.

An easy way to put all outputs from a set of videos under the same directory is to optionally remove the timestamp suffix that is applied by default to each output directory.

**What does this PR do?**
- It adds a flag to the CLI that removes the timestamped suffix from the output directory name.
- It adds tests for the `prep_outputs` method of the tracker class
- It adapts the existing tests for the constructor of the tracker class to use pytest's monkeypatching (rather than unitttest mock).
	- this is to stay consistent with the rest of the tests in the codebase.


## References
Another option could be for the user to be responsible of specifying the full path to the output directory. This is covered in #246. I opted for this option for now, to keep in line with the model evaluation script and the `save_frames` and `frames_output_dir` flags, but this can be reviewed in the future.

## How has this PR been tested?

Tests pass locally and in CI.

## Does this PR require an update to the documentation?

A comment about the new flag has been added to the README.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
