### PR TITLE
Fix pooch retrieval of file registry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       hooks:
           - id: check-manifest
             args: [--no-build-isolation]
-            additional_dependencies: [setuptools-scm]
+            additional_dependencies: [setuptools-scm, wheel]
     # - repo: https://github.com/codespell-project/codespell
     #   # Configuration for codespell is in pyproject.toml
     #   rev: v2.3.0

--- a/tests/fixtures/integration.py
+++ b/tests/fixtures/integration.py
@@ -21,26 +21,28 @@ def pooch_registry() -> dict:
         URL and hash of the GIN repository with the test data
 
     """
+    # Cache the test data in the user's home directory
+    test_data_dir = Path.home() / ".crabs-exploration-test-data"
+
+    # Remove the file registry if it exists
+    # otherwise the registry is not downloaded everytime
+    file_registry_path = test_data_dir / "files-registry.txt"
+    if file_registry_path.is_file():
+        Path(file_registry_path).unlink()
+
     # Initialise pooch registry
     registry = pooch.create(
-        Path.home() / ".crabs-exploration-test-data",
+        test_data_dir,
         base_url=f"{GIN_TEST_DATA_REPO}/raw/master/test_data",
     )
 
     # Download only the registry file from GIN
-    # if known_hash = None, the file is always downloaded.
+    # (this file should always be downloaded fresh from GIN)
     file_registry = pooch.retrieve(
         url=f"{GIN_TEST_DATA_REPO}/raw/master/files-registry.txt",
         known_hash=None,
-        fname="files-registry.txt",
-        # we need to pass a filename otherwise the file is not overwritten
-        # every time!
-        # From the docs: if fname=None, will create a unique file name using
-        # a combination of the last part of the URL (assuming it’s the file
-        # name) and the MD5 hash of the URL. So if fname=None, the file won't
-        # be overwritten while the URL stays the same, even if the content
-        # changes.
-        path=Path.home() / ".crabs-exploration-test-data",
+        fname=file_registry_path.name,
+        path=file_registry_path.parent,
     )
 
     # Load registry file onto pooch registry

--- a/tests/fixtures/integration.py
+++ b/tests/fixtures/integration.py
@@ -32,11 +32,14 @@ def pooch_registry() -> dict:
     file_registry = pooch.retrieve(
         url=f"{GIN_TEST_DATA_REPO}/raw/master/files-registry.txt",
         known_hash=None,
-        fname="files-registry.txt",  
-        # we need to pass a filename otherwise the file is not overwritten every time!
-        # From the docs: if fname=None, will create a unique file name using 
-        # a combination of the last part of the URL (assuming it’s the file 
-        # name) and the MD5 hash of the URL. 
+        fname="files-registry.txt",
+        # we need to pass a filename otherwise the file is not overwritten
+        # every time!
+        # From the docs: if fname=None, will create a unique file name using
+        # a combination of the last part of the URL (assuming it’s the file
+        # name) and the MD5 hash of the URL. So if fname=None, the file won't
+        # be overwritten while the URL stays the same, even if the content
+        # changes.
         path=Path.home() / ".crabs-exploration-test-data",
     )
 

--- a/tests/fixtures/integration.py
+++ b/tests/fixtures/integration.py
@@ -32,6 +32,11 @@ def pooch_registry() -> dict:
     file_registry = pooch.retrieve(
         url=f"{GIN_TEST_DATA_REPO}/raw/master/files-registry.txt",
         known_hash=None,
+        fname="files-registry.txt",  
+        # we need to pass a filename otherwise the file is not overwritten every time!
+        # From the docs: if fname=None, will create a unique file name using 
+        # a combination of the last part of the URL (assuming it’s the file 
+        # name) and the MD5 hash of the URL. 
         path=Path.home() / ".crabs-exploration-test-data",
     )
 


### PR DESCRIPTION
## Description

**What is this PR?**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The file registry file is not overwritten everytime we run tests as we intend.

Right now the `files-registry.txt` file is not always downloaded fresh from GIN. 

The current comment next to the `pooch.retrieve` call incorrectly states that if `known_hash=None` the file is always downloaded. But in fact when `known_hash = None` and the file already exists, the file is NOT downloaded. See the chain of events below:

If `known_hash = None` and the file already exists:
	- > `hash_matches` returns TRUE (see [here](https://github.com/fatiando/pooch/blob/3221e7835d9810f6bcb69e23a6a5c0901d8b9346/pooch/hashes.py#L137))
	- >`download_action` returns "fetch, Fetching" (see [here](https://github.com/fatiando/pooch/blob/3221e7835d9810f6bcb69e23a6a5c0901d8b9346/pooch/core.py#L743))
	-> `pooch.retrieve` does nothing (see [here](https://github.com/fatiando/pooch/blob/3221e7835d9810f6bcb69e23a6a5c0901d8b9346/pooch/core.py#L224))


**What does this PR do?**
To force the download of this file everytime, we need to ensure that the file does not exist before downloading it from GIN. So this PR deletes any files with the expected name at the expected location.

Additionally, 
- I specified a filename in `pooch.retrieve` for the file. Otherwise If filename is None, it is set as `<hash-of-the-url>` + `<last-part-of-url>`. 
- I added `wheel` as an additional dependency to the `check-manifest` precommit, so that it runs correctly in an environment with Python 3.12.

### MWE to reproduce
I assume initially `(Path.home() / ".crabs-exploration-test-data" / "files-registry.txt").is_file()` is `False`.

In a conda environment with `pooch`, and `ipython` (for convenience), start an interactive Python session and run the snippet below.

```
conda create -n mwe-env python=3.12 pooch ipython -y
conda activate mwe-env
ipython
```

<details>
	<summary> Snippet 1 </summary>

```python 
from pathlib import Path
import pooch

GIN_TEST_DATA_REPO = (
    "https://gin.g-node.org/SainsburyWellcomeCentre/crabs-exploration-test-data"
)

# Cache the test data in the user's home directory
test_data_dir = Path.home() / ".crabs-exploration-test-data"

file_registry_path = test_data_dir / "files-registry.txt"

# Initialise pooch registry
registry = pooch.create(
    test_data_dir,
    base_url=f"{GIN_TEST_DATA_REPO}/raw/master/test_data",
)

# Download only the registry file from GIN
# if known_hash = None, the file is always downloaded. ---> Not True
# TODO: change in crabs too!
file_registry = pooch.retrieve(
    url=f"{GIN_TEST_DATA_REPO}/raw/master/files-registry.txt",
    known_hash=None,
    fname=file_registry_path.name,
    path=file_registry_path.parent,
)

# Load registry file onto pooch registry
registry.load_registry(file_registry)
```
</details>

When we run Snippet 1 several times, the file is not re-downloaded. We can verify this because we get the following message only the first time we run the snippet, but not any subsequent ones:
```bash
Downloading data from 'https://gin.g-node.org/SainsburyWellcomeCentre/crabs-exploration-test-data/raw/master/files-registry.txt' to file '/home/sminano/.crabs-exploration-test-data/files-registry.txt'.
SHA256 hash of downloaded file: 34801dd50ddfc5ebf67bb5a205b558197178f999cde325462a5881b8f1fdcc31
Use this value as the 'known_hash' argument of 'pooch.retrieve' to ensure that the file hasn't changed if it is downloaded again in the future.
```

Instead if we add a few lines to remove the "files-registry.txt" file before fetching it from GIN, we see the expected download message everytime.

<details>
	<summary> Snippet 2 </summary>

```python 
from pathlib import Path
import pooch

GIN_TEST_DATA_REPO = (
    "https://gin.g-node.org/SainsburyWellcomeCentre/crabs-exploration-test-data"
)

# Cache the test data in the user's home directory
test_data_dir = Path.home() / ".crabs-exploration-test-data"

# Remove the file registry if it exists
file_registry_path = test_data_dir / "files-registry.txt"
if file_registry_path.is_file():
    Path(file_registry_path).unlink()

# Initialise pooch registry
registry = pooch.create(
    test_data_dir,
    base_url=f"{GIN_TEST_DATA_REPO}/raw/master/test_data",
)

# Download only the registry file from GIN
# if known_hash = None, the file is always downloaded. ---> Not True
# TODO: change in crabs too!
file_registry = pooch.retrieve(
    url=f"{GIN_TEST_DATA_REPO}/raw/master/files-registry.txt",
    known_hash=None,
    fname=file_registry_path.name,
    path=file_registry_path.parent,
)

# Load registry file onto pooch registry
registry.load_registry(file_registry)
```
</details>

## References
\

## How has this PR been tested?
Tests pass locally and in CI.

## Does this PR require an update to the documentation?
\

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
