### PR TITLE
Add steps to avoid category ID null when exporting as COCO in VIA

### DIFF
--- a/guides/ManualLabellingSteps.md
+++ b/guides/ManualLabellingSteps.md
@@ -146,8 +146,8 @@ If we are launching the tool for the first time for a new project:
 - From the fields that appear after clicking `+`, click on `Type` and select `dropdown`.
   - If you now select a bounding box in the image, a dropdown menu to define its category shows up.
 - In the table below,:
-  - add `crab` under `id`
-  - add `crab` under `description`
+  - add `0` under `id` - we select `0` but this can be any number that we map to the category `crab`.
+  - add `crab` under `description` - this will set the `category` for the bounding box.
   - select the radio button under `def` - this sets all annotations to be `crabs` by default. If we don't do these none of the annotations will be labelled.
 - To visualise the Annotator Editor for the current frame, press `spacebar`
   - The dropdown menu for a bounding box does not show up if annotator editor is visible.


### PR DESCRIPTION
## Description

**What is this PR?**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

Ensures the category ID entered is a number, so that the COCO export works correctly.

**Why is this PR needed?**
When following the steps, the data exported in COCO format produced a `null` category.

This is because COCO does not accept a string category ID (but VIA does).

**What does this PR do?**
Clarifies in the labelling guide that the category ID needs to be an integer

## References

[this issue](https://gitlab.com/vgg/via/-/issues/296) from the VIA tool

## How has this PR been tested?

Separately using the VIA tool.

## Does this PR require an update to the documentation?

It is an update of the existing guides.

## Checklist:

- [ n/a ] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
