### PR TITLE
Evaluation small fixes

### DIFF
--- a/crabs/detector/config/faster_rcnn.yaml
+++ b/crabs/detector/config/faster_rcnn.yaml
@@ -32,7 +32,7 @@ checkpoint_saving:
 # Evaluation parameters
 # -----------------------
 iou_threshold: 0.1
-batch_size_test: 4
+batch_size_test: 1
 
 # -------------------
 # Data augmentation

--- a/crabs/detector/utils/visualization.py
+++ b/crabs/detector/utils/visualization.py
@@ -70,7 +70,7 @@ def draw_bbox(
         )
 
 
-def draw_detection(
+def draw_detections(
     imgs: list,
     annotations: dict,
     detections: Optional[dict[Any, Any]] = None,
@@ -201,7 +201,7 @@ def save_images_with_boxes(
 
             detections = trained_model(imgs)
 
-            imgs_with_boxes = draw_detection(
+            imgs_with_boxes = draw_detections(
                 imgs, annotations, detections, score_threshold
             )
 

--- a/crabs/detector/utils/visualization.py
+++ b/crabs/detector/utils/visualization.py
@@ -115,7 +115,7 @@ def draw_detections(
                 image_with_boxes,
                 ((target_boxes[i][0])[0], (target_boxes[i][0])[1]),
                 ((target_boxes[i][1])[0], (target_boxes[i][1])[1]),
-                colour=(0, 255, 0),
+                colour=(0, 255, 0),  # RGB format
             )
         if prediction:
             pred_score = list(prediction["scores"].detach().cpu().numpy())
@@ -148,7 +148,7 @@ def draw_detections(
                             (pred_boxes[i][1])[0],
                             (pred_boxes[i][1])[1],
                         ),
-                        (0, 0, 255),
+                        (255, 0, 0),  # RGB format
                         label_text,
                     )
         list_images_with_boxes.append(image_with_boxes)
@@ -208,7 +208,9 @@ def save_images_with_boxes(
             for img_id, img_with_boxes in enumerate(imgs_with_boxes):
                 cv2.imwrite(
                     f"{output_dir}/img_batch_{batch_id}_{img_id}.jpg",
-                    img_with_boxes,
+                    cv2.cvtColor(img_with_boxes, cv2.COLOR_RGB2BGR),
+                    # change to BGR format as opencv expects; note this
+                    # is not required if the image is read with opencv
                 )
 
 

--- a/tests/test_unit/test_visualization.py
+++ b/tests/test_unit/test_visualization.py
@@ -7,7 +7,7 @@ import torch
 
 from crabs.detector.utils.visualization import (
     draw_bbox,
-    draw_detection,
+    draw_detections,
     save_images_with_boxes,
 )
 
@@ -144,9 +144,9 @@ def test_draw_bbox_green(sample_image, top_left, bottom_right, color):
         ),
     ],
 )
-def test_draw_detection(annotations, detections):
+def test_draw_detections(annotations, detections):
     imgs = [torch.rand(3, 100, 100)]
-    image_with_boxes = draw_detection(imgs, annotations, detections)
+    image_with_boxes = draw_detections(imgs, annotations, detections)
     assert image_with_boxes is not None
 
 


### PR DESCRIPTION
- Save all images per batch if requested during evaluation
    - The visualisation function `draw_detection` was only returning one image, but processing all input images in a batch. This PR fixes it to return all images
- Set "default" batch size for test set to 1
    - Right now, in the train, val and test set we compute the average precision and recall per batch, and then take the average for one epoch. 
    - This is alright to check the progress during training (note that there is a gradient update after each batch), but less so when evaluating the model (using the test set for reporting, or the validation set for selection)
    - In validation and testing it makes more sense to compute precision and recall aggregating detections across all batches. Ideally we compute mAP that takes the mean over IOU values (rn the IOU threshold is set to 0.1). An easy way to implement this would be using [torchmetrics](https://lightning.ai/docs/torchmetrics/stable/pages/overview.html#structure-overview) (see #158)
 - Set correct colormap for cv2.imwrite
     - opencv assumes images are in BGR format but the tensor is in RGB
 