### PR TITLE
Set default score threshold to 0 when exporting evaluation frames

### DIFF
--- a/crabs/detector/evaluate_model.py
+++ b/crabs/detector/evaluate_model.py
@@ -302,10 +302,10 @@ def evaluate_parse_args(args):
     parser.add_argument(
         "--frames_score_threshold",
         type=float,
-        default=0.5,
+        default=0.0,
         help=(
             "Score threshold for visualising detections on output frames. "
-            "Default: 0.5"
+            "Default: 0.0"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
We offer the possibility to export the frames used in evaluation for troubleshooting.

The predicted detections and the groundtruth are both plotted in the evaluation frames. However, by default, only the detections with a score above 0.5 are shown. 

This PR changes that default to 0.0, to avoid confusion with the reported precision and recall values and the plotted results. 