### PR TITLE
Simplified precision recall (w/ Hungarian matching) + train test

### DIFF
--- a/crabs/detector/models.py
+++ b/crabs/detector/models.py
@@ -227,13 +227,6 @@ class FasterRCNN(LightningModule):
     ) -> dict[str, Union[float, int]]:
         """Define the validation step for the model."""
         outputs = self.val_test_step(batch)
-
-        # log to screen
-        logging.info(
-            f"batch {batch_idx} Precision: {outputs['precision']:.4f},"
-            f"batch {batch_idx} Recall: {outputs['recall']:.4f}"
-        )
-
         self.accumulate_epoch_metrics(outputs, "validation")
         return outputs
 

--- a/crabs/detector/models.py
+++ b/crabs/detector/models.py
@@ -10,7 +10,9 @@ from torchvision.models.detection import (
     fasterrcnn_resnet50_fpn_v2,
 )
 
-from crabs.detector.utils.evaluate import compute_confusion_matrix_elements
+from crabs.detector.utils.evaluate import (
+    compute_precision_recall,
+)
 
 
 class FasterRCNN(LightningModule):
@@ -214,9 +216,10 @@ class FasterRCNN(LightningModule):
         images, targets = batch
         predictions = self.model(images)
 
-        precision, recall, _ = compute_confusion_matrix_elements(
-            targets, predictions, self.config["iou_threshold"]
+        precision, recall = compute_precision_recall(
+            predictions, targets, self.config["iou_threshold"]
         )
+
         return {"precision": precision, "recall": recall}
 
     def validation_step(
@@ -224,6 +227,13 @@ class FasterRCNN(LightningModule):
     ) -> dict[str, Union[float, int]]:
         """Define the validation step for the model."""
         outputs = self.val_test_step(batch)
+
+        # log to screen
+        logging.info(
+            f"batch {batch_idx} Precision: {outputs['precision']:.4f},"
+            f"batch {batch_idx} Recall: {outputs['recall']:.4f}"
+        )
+
         self.accumulate_epoch_metrics(outputs, "validation")
         return outputs
 

--- a/crabs/detector/utils/evaluate.py
+++ b/crabs/detector/utils/evaluate.py
@@ -117,6 +117,7 @@ def evaluate_detections_hungarian(
         # Mark true positives and false positives based on optimal assignment
         for pred_idx, gt_idx in zip(pred_indices, gt_indices, strict=True):
             if iou_matrix[pred_idx, gt_idx] > iou_threshold:
+                true_positives[pred_idx] = True
                 matched_gts[gt_idx] = True
             else:
                 false_positives[pred_idx] = True

--- a/crabs/detector/utils/evaluate.py
+++ b/crabs/detector/utils/evaluate.py
@@ -100,14 +100,7 @@ def evaluate_detections_hungarian(
 
     if len(pred_bboxes) > 0 and len(gt_bboxes) > 0:
         # Compute IoU matrix (pred_bboxes x gt_bboxes)
-        iou_matrix = (
-            ops.box_iou(
-                torch.tensor(pred_bboxes, dtype=torch.float32),
-                torch.tensor(gt_bboxes, dtype=torch.float32),
-            )
-            .cpu()
-            .numpy()
-        )
+        iou_matrix = ops.box_iou(pred_bboxes, gt_bboxes).cpu().numpy()
 
         # Use Hungarian algorithm to find optimal assignment
         pred_indices, gt_indices = linear_sum_assignment(

--- a/crabs/detector/utils/evaluate.py
+++ b/crabs/detector/utils/evaluate.py
@@ -6,6 +6,9 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+import numpy as np
+import scipy
+import torch
 import torchvision
 import yaml  # type: ignore
 
@@ -15,13 +18,21 @@ from crabs.detector.utils.detection import (
 )
 
 
-def compute_precision_recall(class_stats: dict) -> tuple[float, float, dict]:
+def compute_precision_recall(
+    pred_dicts_batch: list, gt_dicts_batch: list, iou_threshold: float
+) -> tuple[float, float]:
     """Compute precision and recall.
 
     Parameters
     ----------
-    class_stats : dict
-        Statistics or information about different classes.
+    pred_dicts_batch : list
+        A list of prediction dictionaries for each element in the batch
+        with keys 'boxes', 'labels', and 'scores'
+    gt_dicts_batch : list
+        A list of ground truth dictionaries for each element in the batch
+        with keys 'image_id', 'boxes', 'labels'.
+    iou_threshold : float
+        IoU threshold for considering a detection as true positive
 
     Returns
     -------
@@ -29,87 +40,174 @@ def compute_precision_recall(class_stats: dict) -> tuple[float, float, dict]:
         precision and recall
 
     """
-    for _, stats in class_stats.items():
-        precision = stats["tp"] / max(stats["tp"] + stats["fp"], 1)
-        recall = stats["tp"] / max(stats["tp"] + stats["fn"], 1)
+    eval_results = evaluate_detections_hungarian(
+        pred_dicts_batch, gt_dicts_batch, iou_threshold
+    )
 
-    return precision, recall, class_stats
+    precision = eval_results["tp"] / (eval_results["tp"] + eval_results["fp"])
+    recall = eval_results["tp"] / (eval_results["tp"] + eval_results["fn"])
+
+    return precision, recall
 
 
-def compute_confusion_matrix_elements(
-    targets: list, detections: list, ious_threshold: float
-) -> tuple[float, float, dict]:
-    """Compute detection metrics.
-
-    Compute true positive, false positive, and false negative values.
+def evaluate_detections_hungarian(
+    pred_dicts_batch: list, gt_dicts_batch: list, iou_threshold: float
+) -> dict:
+    """Evaluate detection performance using Hungarian algorithm for matching.
 
     Parameters
     ----------
-    targets : list
-        Ground truth annotations.
-    detections : list
-        Detected objects.
-    ious_threshold  : float
-        The threshold value for the intersection-over-union (IOU).
-        Only detections whose IOU relative to the ground truth is above the
-        threshold are true positive candidates.
-    class_stats : dict
-        Statistics or information about different classes.
+    pred_dicts_batch : list
+        A list of prediction dictionaries for each element in the batch
+        with keys 'boxes', 'labels', and 'scores'
+    gt_dicts_batch : list
+        A list of ground truth dictionaries for each element in the batch
+        with keys 'image_id', 'boxes', 'labels'.
+    iou_threshold : float
+        IoU threshold for considering a detection as true positive
 
     Returns
     -------
-    Tuple[float, float]
-        precision and recall
+    dict
+        Dictionary with keys "tp", "fp", and "fn"
+        - tp: number of true positives
+        - fp: number of false positives
+        - fn: number of missed detections (false negatives)
 
     """
-    class_stats = {"crab": {"tp": 0, "fp": 0, "fn": 0}}
-    for target, detection in zip(targets, detections):
-        gt_boxes = target["boxes"]
-        pred_boxes = detection["boxes"]
-        pred_labels = detection["labels"]
+    # Concatenate detections and ground truth boxes across the batch
+    pred_bboxes = torch.cat(
+        [pred_dict["boxes"] for pred_dict in pred_dicts_batch]
+    )
+    gt_bboxes = torch.cat([gt_dict["boxes"] for gt_dict in gt_dicts_batch])
 
-        ious = torchvision.ops.box_iou(pred_boxes, gt_boxes)
+    # Initialize output arrays
+    true_positives = np.zeros(len(pred_bboxes), dtype=bool)
+    false_positives = np.zeros(len(pred_bboxes), dtype=bool)
+    matched_gts = np.zeros(len(gt_bboxes), dtype=bool)
+    missed_detections = np.zeros(len(gt_bboxes), dtype=bool)  # unmatched gts
 
-        max_ious, max_indices = ious.max(dim=1)
+    if len(pred_bboxes) > 0 and len(gt_bboxes) > 0:
+        # Convert to tensors for batch IoU computation
+        pred_tensor = torch.tensor(pred_bboxes[:, :4], dtype=torch.float32)
+        gt_tensor = torch.tensor(gt_bboxes, dtype=torch.float32)
 
-        # Identify true positives, false positives, and false negatives
-        for idx, iou in enumerate(max_ious):
-            if iou.item() > ious_threshold:
-                pred_class_idx = pred_labels[idx].item()
-                true_label = target["labels"][max_indices[idx]].item()
+        # Compute IoU matrix (pred_bboxes x gt_bboxes)
+        iou_matrix = (
+            torchvision.ops.box_iou(pred_tensor, gt_tensor).cpu().numpy()
+        )
 
-                if pred_class_idx == true_label:
-                    class_stats["crab"]["tp"] += 1
-                else:
-                    class_stats["crab"]["fp"] += 1
+        # Apply IoU threshold: set IoU below threshold to 0 (no match)
+        iou_matrix[iou_matrix < iou_threshold] = 0
+
+        # Use Hungarian algorithm to find optimal assignment
+        pred_indices, gt_indices = scipy.optimize.linear_sum_assignment(
+            iou_matrix, maximize=True
+        )
+
+        # Mark true positives and false positives based on optimal assignment
+        for pred_idx, gt_idx in zip(pred_indices, gt_indices, strict=True):
+            if iou_matrix[pred_idx, gt_idx] > 0:  # IoU above threshold
+                true_positives[pred_idx] = True
+                matched_gts[gt_idx] = True
             else:
-                class_stats["crab"]["fp"] += 1
+                false_positives[pred_idx] = True
 
-        for target_box_index, _target_box in enumerate(gt_boxes):
-            found_match = False
-            for idx, iou in enumerate(max_ious):
-                if (
-                    iou.item() > ious_threshold
-                    # we need this condition because the max overlap
-                    # is not necessarily above the threshold
-                    and max_indices[idx] == target_box_index
-                    # the matching index is the index of the GT
-                    # box with which it has max overlap
-                ):
-                    # There's an IoU match and the matched index corresponds
-                    # to the current target_box_index
-                    found_match = True
-                    break  # Exit loop, a match was found
+        # Mark unmatched predictions as false positives
+        false_positives[~true_positives] = True
 
-            if not found_match:
-                # print(found_match)
-                class_stats["crab"]["fn"] += (
-                    1  # Ground truth box has no corresponding detection
-                )
+        # Mark unmatched ground truth as missed detections
+        missed_detections[~matched_gts] = True
 
-    precision, recall, class_stats = compute_precision_recall(class_stats)
+    elif len(pred_bboxes) == 0 and len(gt_bboxes) > 0:
+        # No predictions, all ground truth are missed
+        missed_detections[:] = True
+    elif len(pred_bboxes) > 0 and len(gt_bboxes) == 0:
+        # No ground truth, all predictions are false positives
+        false_positives[:] = True
 
-    return precision, recall, class_stats
+    # Return sum as a dict
+    return {
+        "tp": true_positives.sum().item(),
+        "fp": false_positives.sum().item(),
+        "fn": missed_detections.sum().item(),
+    }
+
+
+# def compute_confusion_matrix_elements(
+#     targets: list, detections: list, ious_threshold: float
+# ) -> tuple[float, float, dict]:
+#     """Compute detection metrics.
+
+#     Compute true positive, false positive, and false negative values.
+
+#     Parameters
+#     ----------
+#     targets : list
+#         Ground truth annotations.
+#     detections : list
+#         Detected objects.
+#     ious_threshold  : float
+#         The threshold value for the intersection-over-union (IOU).
+#         Only detections whose IOU relative to the ground truth is above the
+#         threshold are true positive candidates.
+#     class_stats : dict
+#         Statistics or information about different classes.
+
+#     Returns
+#     -------
+#     Tuple[float, float]
+#         precision and recall
+
+#     """
+#     class_stats = {"crab": {"tp": 0, "fp": 0, "fn": 0}}
+#     for target, detection in zip(targets, detections):
+#         gt_boxes = target["boxes"]
+#         pred_boxes = detection["boxes"]
+#         pred_labels = detection["labels"]
+
+#         ious = torchvision.ops.box_iou(pred_boxes, gt_boxes)
+
+#         max_ious, gt_idx_match = ious.max(dim=1)
+
+#         # Identify true positives, false positives, and false negatives
+#         for idx, iou in enumerate(max_ious):
+#             if iou.item() > ious_threshold:
+#                 pred_label = pred_labels[idx].item()
+#                 true_label = target["labels"][gt_idx_match[idx]].item()
+
+#                 if pred_label == true_label:
+#                     class_stats["crab"]["tp"] += 1
+#                 else:
+#                     class_stats["crab"]["fp"] += 1
+#             else:
+#                 class_stats["crab"]["fp"] += 1
+
+#         for gt_box_index, _ in enumerate(gt_boxes):
+#             found_match = False
+#             for idx, iou in enumerate(max_ious):
+#                 if (
+#                     iou.item() > ious_threshold
+#                     # we need this condition because the max overlap
+#                     # is not necessarily above the threshold
+#                     and gt_idx_match[idx] == gt_box_index
+#                     # the matching index is the index of the GT
+#                     # box with which it has max overlap
+#                 ):
+#                     # There's an IoU match and the matched index corresponds
+#                     # to the current target_box_index
+#                     found_match = True
+#                     break  # Exit loop, a match was found
+
+#             if not found_match:
+#                 # print(found_match)
+#                 class_stats["crab"]["fn"] += (
+#                     1  # Ground truth box has no corresponding detection
+#                 )
+
+#     precision, recall, class_stats = compute_precision_recall(class_stats)
+
+#     return precision, recall, class_stats
 
 
 def get_mlflow_parameters_from_ckpt(trained_model_path: str) -> dict:

--- a/crabs/detector/utils/evaluate.py
+++ b/crabs/detector/utils/evaluate.py
@@ -103,12 +103,13 @@ def evaluate_detections_hungarian(
         iou_matrix = ops.box_iou(pred_bboxes, gt_bboxes).cpu().numpy()
 
         # Use Hungarian algorithm to find optimal assignment
+        # note: pred_indices.shape == gt_indices.shape (both are 1D arrays)
         pred_indices, gt_indices = linear_sum_assignment(
             iou_matrix, maximize=True
         )
 
         # Mark true positives and false positives based on optimal assignment
-        for pred_idx, gt_idx in zip(pred_indices, gt_indices, strict=True):
+        for pred_idx, gt_idx in zip(pred_indices, gt_indices):
             if iou_matrix[pred_idx, gt_idx] > iou_threshold:
                 true_positives[pred_idx] = True
                 matched_gts[gt_idx] = True

--- a/tests/test_integration/test_train.py
+++ b/tests/test_integration/test_train.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import subprocess
 from pathlib import Path
 
@@ -6,6 +7,12 @@ import numpy as np
 import pooch
 import pytest
 import yaml
+
+# Set the start method to fork to avoid issues with macOS-13 CI tests
+# failing with "RuntimeError: Please call `iter(combined_loader)` first"
+# when num_workers > 0, Python 3.10 and macOS-13.
+# https://github.com/pytorch/pytorch/issues/46648
+multiprocessing.set_start_method("fork")
 
 
 @pytest.fixture()

--- a/tests/test_integration/test_train.py
+++ b/tests/test_integration/test_train.py
@@ -1,0 +1,68 @@
+import subprocess
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pooch
+import pytest
+
+
+@pytest.fixture()
+def input_data_paths(pooch_registry: pooch.Pooch, tmp_path: Path):
+    """Input data for a detector+tracking run.
+
+    The data is fetched from the pooch registry.
+    """
+    # Create a directory with black small frames under tmp_path
+    black_frames_dir = tmp_path / "black_frames"
+    black_frames_dir.mkdir(parents=True, exist_ok=False)
+    for i in range(100):
+        black_frame = np.zeros((10, 10, 3), dtype=np.uint8)
+        cv2.imwrite(black_frames_dir / f"{i:08d}.jpg", black_frame)
+
+    # Get an annotation file from pooch for 100 frames
+    annotation_file = pooch_registry.fetch(
+        "sample_train_data/annotations_100frames.json"
+    )
+
+    return {
+        "dataset_dir": black_frames_dir,
+        "annotation_file": annotation_file,
+        "seed_n": "42",
+        "accelerator": "cpu",
+        "experiment_name": "test_train_detector",
+        "limit_train_batches": "0.01",
+    }
+
+
+def test_train_detector(input_data_paths: dict, tmp_path: Path):
+    # Define command
+    main_command = [
+        "train-detector",
+        f"--dataset_dirs={input_data_paths['dataset_dir']}",
+        f"--annotation_files={input_data_paths['annotation_file']}",
+        f"--seed_n={input_data_paths['seed_n']}",
+        f"--accelerator={input_data_paths['accelerator']}",
+        f"--experiment_name={input_data_paths['experiment_name']}",
+        "--log_data_augmentation",
+        "--fast_dev_run",
+        f"--limit_train_batches={input_data_paths['limit_train_batches']}",
+    ]
+
+    # Run command
+    completed_process = subprocess.run(
+        main_command,
+        check=True,
+        cwd=tmp_path,
+        # set cwd to Pytest's temporary directory
+        # so the output is saved there
+    )
+
+    # check the command runs successfully
+    assert completed_process.returncode == 0
+
+    # check mlflow folder is created
+
+    # check data augmentation is logged
+
+    # check model is trained?

--- a/tests/test_integration/test_train.py
+++ b/tests/test_integration/test_train.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import subprocess
 from pathlib import Path
 
@@ -7,12 +6,6 @@ import numpy as np
 import pooch
 import pytest
 import yaml
-
-# Set the start method to fork to avoid issues with macOS-13 CI tests
-# failing with "RuntimeError: Please call `iter(combined_loader)` first"
-# when num_workers > 0, Python 3.10 and macOS-13.
-# https://github.com/pytorch/pytorch/issues/46648
-multiprocessing.set_start_method("fork")
 
 
 @pytest.fixture()

--- a/tests/test_integration/test_train.py
+++ b/tests/test_integration/test_train.py
@@ -5,6 +5,7 @@ import cv2
 import numpy as np
 import pooch
 import pytest
+import yaml
 
 
 @pytest.fixture()
@@ -27,9 +28,28 @@ def input_data_paths(pooch_registry: pooch.Pooch, tmp_path: Path):
         "sample_train_data/annotations_100frames.json"
     )
 
+    # Read the reference config file
+    reference_config_file = (
+        Path(__file__).parents[2] / "crabs/detector/config/faster_rcnn.yaml"
+    )
+    with open(reference_config_file) as f:
+        reference_config = yaml.safe_load(f)
+
+    # Modify the config file to have num_workers = 0 and
+    # save it at tmp_path
+    # This is to avoid issues with macOS-13 CI tests failing with
+    # "RuntimeError: Please call `iter(combined_loader)` first"
+    # when num_workers > 0, Python 3.9 and macOS-13.
+    # https://github.com/pytorch/pytorch/issues/46648
+    reference_config["num_workers"] = 0
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump(reference_config, f)
+
     return {
         "dataset_dir": black_frames_dir.parent,
         "annotation_file": annotation_file,
+        "config_file": config_file,
         "seed_n": "42",
         "accelerator": "cpu",
         "experiment_name": "test_train_detector",
@@ -43,6 +63,7 @@ def test_train_detector(input_data_paths: dict, tmp_path: Path):
         "train-detector",
         f"--dataset_dirs={input_data_paths['dataset_dir']}",
         f"--annotation_files={input_data_paths['annotation_file']}",
+        f"--config_file={input_data_paths['config_file']}",
         f"--seed_n={input_data_paths['seed_n']}",
         f"--accelerator={input_data_paths['accelerator']}",
         f"--experiment_name={input_data_paths['experiment_name']}",

--- a/tests/test_unit/test_evaluate.py
+++ b/tests/test_unit/test_evaluate.py
@@ -1,74 +1,72 @@
+from unittest.mock import patch
+
+import pytest
 import torch
 
 from crabs.detector.utils.evaluate import (
-    compute_confusion_matrix_elements,
     compute_precision_recall,
+    evaluate_detections_hungarian,
 )
 
 
-def test_compute_precision_recall():
-    class_stats = {"crab": {"tp": 10, "fp": 2, "fn": 1}}
+def test_evaluate_detections_hungarian():
+    # sample boxes  xyxy
+    box_1 = torch.tensor([27, 11, 63, 33])
+    box_2 = torch.tensor([87, 4, 118, 23])
+    box_3 = torch.tensor([154, 152, 192, 164])
+    delta_box = torch.tensor([3, 0, 82, 0])
 
-    precision, recall, _ = compute_precision_recall(class_stats)
-
-    assert precision == class_stats["crab"]["tp"] / max(
-        class_stats["crab"]["tp"] + class_stats["crab"]["fp"],
-        class_stats["crab"]["fn"],
-    )
-    assert recall == class_stats["crab"]["tp"] / max(
-        class_stats["crab"]["tp"] + class_stats["crab"]["fn"],
-        class_stats["crab"]["fn"],
-    )
-
-
-def test_compute_precision_recall_zero_division():
-    class_stats = {"crab": {"tp": 0, "fp": 0, "fn": 0}}
-
-    precision, recall, _ = compute_precision_recall(class_stats)
-
-    # Assert expected precision and recall values when all counts are zero
-    assert precision == max(
-        class_stats["crab"]["tp"] + class_stats["crab"]["fp"],
-        class_stats["crab"]["fn"],
-    )
-    assert recall == max(
-        class_stats["crab"]["tp"] + class_stats["crab"]["fp"],
-        class_stats["crab"]["fn"],
-    )
-
-
-def test_compute_confusion_matrix_elements():
-    # ground truth
-    gt_box_1 = torch.tensor([27, 11, 63, 33])
-    gt_box_2 = torch.tensor([87, 4, 118, 23])
-    gt_box_3 = torch.tensor([154, 152, 192, 164])
-    gt_labels = torch.tensor([1, 1, 1])
-    # predictions
-    delta_box_2 = torch.tensor([3, 0, 82, 0])
-    detection_labels = torch.tensor([1, 1])
-    detection_scores = torch.tensor([0.5083, 0.4805])
-    targets = [
-        {
-            "image_id": 1,
-            "boxes": torch.vstack((gt_box_1, gt_box_2, gt_box_3)),
-            "labels": gt_labels,
-        }
-    ]
-    detections = [
-        {
-            "boxes": torch.vstack((gt_box_1, gt_box_2 + delta_box_2)),
-            "labels": detection_labels,
-            "scores": detection_scores,
-        }
-    ]
     ious_threshold = 0.5
 
-    precision, recall, class_stats = compute_confusion_matrix_elements(
-        targets, detections, ious_threshold
+    gt_dicts_batch = [
+        {
+            "image_id": 1,
+            "boxes": torch.vstack((box_1, box_2, box_3)),
+            "labels": torch.tensor([1, 1, 1]),
+        }
+    ]
+    detections_dicts_batch = [
+        {
+            "boxes": torch.vstack((box_1, box_2 + delta_box)),
+            "labels": torch.tensor([1, 1]),
+            "scores": torch.tensor([0.5083, 0.4805]),
+        }
+    ]
+
+    results = evaluate_detections_hungarian(
+        detections_dicts_batch, gt_dicts_batch, ious_threshold
     )
 
-    assert precision == 0.5
-    assert recall == 1 / 3
-    assert class_stats["crab"]["tp"] == 1
-    assert class_stats["crab"]["fp"] == 1
-    assert class_stats["crab"]["fn"] == 2
+    assert results["tp"] == 1
+    assert results["fp"] == 1
+    assert results["fn"] == 2
+
+
+@pytest.mark.parametrize(
+    "mocked_results,expected_precision_recall",
+    [
+        (
+            {"tp": 10, "fp": 2, "fn": 1},
+            {"precision": 10 / 12, "recall": 10 / 11},
+        ),
+        (
+            {"tp": 0, "fp": 0, "fn": 0},
+            {"precision": 0.0, "recall": 0.0},
+            # all counts are zero
+        ),
+    ],
+)
+def test_compute_precision_recall(mocked_results, expected_precision_recall):
+    # Mock the evaluate_detections_hungarian function
+    with patch(
+        "crabs.detector.utils.evaluate.evaluate_detections_hungarian"
+    ) as mock_evaluate:
+        # mock the return value of `evaluate_detections_hungarian`
+        # (called by `compute_precision_recall`)
+        mock_evaluate.return_value = mocked_results
+
+        # compute precision and recall
+        precision, recall = compute_precision_recall([], [], 0)
+
+    assert precision == expected_precision_recall["precision"]
+    assert recall == expected_precision_recall["recall"]

--- a/tests/test_unit/test_evaluate.py
+++ b/tests/test_unit/test_evaluate.py
@@ -31,15 +31,18 @@ def test_evaluate_detections_hungarian():
             "labels": torch.tensor([1, 1]),
             "scores": torch.tensor([0.5083, 0.4805]),
         }
-    ]
+    ]  # IOU of box_2 and box_2 + delta_box is 0.2478
 
     results = evaluate_detections_hungarian(
         detections_dicts_batch, gt_dicts_batch, ious_threshold
     )
 
-    assert results["tp"] == 1
-    assert results["fp"] == 1
-    assert results["fn"] == 2
+    assert results == {"tp": 1, "fp": 1, "fn": 2}
+    assert (
+        results["tp"] + results["fp"]
+        == detections_dicts_batch[0]["boxes"].shape[0]
+    )
+    assert results["tp"] + results["fn"] == gt_dicts_batch[0]["boxes"].shape[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR?**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other


**What does this PR do?**
- Simplify / fix calculations of precision / recall
	- remove distinctions per class 
		- they were unused, all detections are the same class for us
	- use Hungarian algorithm to match predictions and ground truth
		- a bit more efficient, and easily avoids several predictions being matched to the same ground truth 
		- the approach we were using before is similar to another standard one except we didn't sort the predictions by confidence score before matching.
	- consider case in which all counts (TP, MD, FP) are zero in implementation
	- adapt tests
- Add a smoke test for training

## How has this PR been tested?

Tests pass locally and in CI.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
