### PR TITLE
MLflow env var + movement singular dims + Python support increase

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
         include:
           - os: macos-latest  # Apple chip macOS
-            python-version: "3.12"
+            python-version: "3.13"
     steps:
       - name: Cache test data
         uses: actions/cache@v4

--- a/crabs/detector/__init__.py
+++ b/crabs/detector/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+# Allow MLflow's filesystem tracking backend (deprecated since MLflow 3.8, but
+# still required for our file:// tracking URIs and file-store checkpoints). Set
+# here, before any submodule imports mlflow, so it applies package-wide. Set as
+# a default so it can still be overridden via the environment.
+os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")

--- a/crabs/utils/create_zarr_dataset.py
+++ b/crabs/utils/create_zarr_dataset.py
@@ -41,7 +41,7 @@ warnings.filterwarnings(
 DEFAULT_CHUNK_SIZES = {
     "time": 1000,
     "space": -1,
-    "individuals": -1,
+    "individual": -1,
     "clip_id": 1,
 }
 
@@ -196,10 +196,8 @@ def _renumber_individuals(ds: xr.Dataset, width: int) -> xr.Dataset:
     Numbers are reset to range from 0 to N-1, with N being the maximum
     number of individuals.
     """
-    n = len(ds.individuals)
-    return ds.assign_coords(
-        individuals=[f"id_{i:0{width}d}" for i in range(n)]
-    )
+    n = len(ds.individual)
+    return ds.assign_coords(individual=[f"id_{i:0{width}d}" for i in range(n)])
 
 
 def create_temp_zarr_store(
@@ -316,7 +314,7 @@ def create_final_zarr_store(
             clip_node.to_dataset() for clip_node in dt_video.leaves
         ]
 
-        max_n_individuals = max(len(ds.individuals) for ds in list_clip_ds)
+        max_n_individuals = max(len(ds.individual) for ds in list_clip_ds)
         id_width = len(str(max_n_individuals - 1))
 
         # Concatenate all clip datasets along the clip_id dimension

--- a/notebooks/notebook_fix_annotations_file.py
+++ b/notebooks/notebook_fix_annotations_file.py
@@ -93,6 +93,6 @@ print(ds_gt)
 # Print summary
 print(f"{ds_gt.source_file}")
 print(f"Number of frames: {ds_gt.sizes['time']}")
-print(f"Number of individuals: {ds_gt.sizes['individuals']}")
+print(f"Number of individuals: {ds_gt.sizes['individual']}")
 
 # %%

--- a/notebooks/notebook_movement_escapes.ipynb
+++ b/notebooks/notebook_movement_escapes.ipynb
@@ -162,41 +162,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "697a1fcb-1f14-4f95-83ec-40696da9a710",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "04.09.2023-01-Right-Spontaneous1_tracks.csv\n",
-      "Number of frames: 187\n",
-      "Number of individuals: 105\n",
-      "<xarray.Dataset> Size: 789kB\n",
-      "Dimensions:      (time: 187, individuals: 105, space: 2)\n",
-      "Coordinates:\n",
-      "  * time         (time) int64 1kB 0 1 2 3 4 5 6 ... 180 181 182 183 184 185 186\n",
-      "  * individuals  (individuals) <U6 3kB 'id_1' 'id_2' ... 'id_105' 'id_107'\n",
-      "  * space        (space) <U1 8B 'x' 'y'\n",
-      "Data variables:\n",
-      "    position     (time, individuals, space) float64 314kB 3.285e+03 ... 119.5\n",
-      "    shape        (time, individuals, space) float64 314kB 46.0 58.0 ... 33.0\n",
-      "    confidence   (time, individuals) float64 157kB 0.6846 0.7115 ... 0.9999 1.0\n",
-      "Attributes:\n",
-      "    fps:              None\n",
-      "    time_unit:        frames\n",
-      "    source_software:  VIA-tracks\n",
-      "    source_file:      /home/sminano/swc/project_crabs/escape_clips_tracking_o...\n",
-      "    ds_type:          bboxes\n",
-      "--------------------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(Path(ds.source_file).name)\n",
     "print(f\"Number of frames: {ds.sizes['time']}\")\n",
-    "print(f\"Number of individuals: {ds.sizes['individuals']}\")\n",
+    "print(f\"Number of individuals: {ds.sizes['individual']}\")\n",
     "print(ds)\n",
     "print(\"--------------------\")"
    ]
@@ -212,13 +185,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "aaf4dacf-e9a4-427b-b69f-7364b5118e50",
    "metadata": {},
    "outputs": [],
    "source": [
     "non_nan_frames_per_ID = {}\n",
-    "for ind, _id_str in enumerate(ds.individuals):\n",
+    "for ind, _id_str in enumerate(ds.individual):\n",
     "    non_nan_frames_per_ID[ind] = (\n",
     "        len(ds.time) - ds.position[:, ind, :].isnull().any(axis=1).sum().item()\n",
     "    )"
@@ -265,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "c07deb60-cd6e-47b3-a2f9-6c01c52e2b4f",
    "metadata": {},
    "outputs": [
@@ -282,7 +255,7 @@
    ],
    "source": [
     "fig, ax = plt.subplots(1, 1)\n",
-    "for ind_idx in range(ds.sizes[\"individuals\"]):\n",
+    "for ind_idx in range(ds.sizes[\"individual\"]):\n",
     "    # plot trajectories\n",
     "    ax.scatter(\n",
     "        x=ds.position[:, ind_idx, 0],  # nframes, nindividuals, x\n",
@@ -296,7 +269,7 @@
     "        ax.text(\n",
     "            x=ds.position[start_frame, ind_idx, 0],\n",
     "            y=ds.position[start_frame, ind_idx, 1],\n",
-    "            s=ds.individuals[ind_idx].item().split(\"_\")[1],\n",
+    "            s=ds.individual[ind_idx].item().split(\"_\")[1],\n",
     "            fontsize=8,\n",
     "            color=list_colors[ind_idx % len(list_colors)],\n",
     "        )\n",
@@ -326,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "1f54d085-e579-4a5b-abea-d2cf00d8930b",
    "metadata": {},
    "outputs": [
@@ -352,7 +325,7 @@
     "ax.set_xlabel(\"n frames with same ID\")\n",
     "ax.set_ylabel(\"n trajectories\")\n",
     "ax.hlines(\n",
-    "    y=len(ds.individuals),\n",
+    "    y=len(ds.individual),\n",
     "    xmin=0,\n",
     "    xmax=len(ds.time),\n",
     "    color=\"red\",\n",

--- a/notebooks/notebook_movement_trajectories_gt.py
+++ b/notebooks/notebook_movement_trajectories_gt.py
@@ -37,7 +37,7 @@ print(ds_gt)
 # Print summary
 print(f"{ds_gt.source_file}")
 print(f"Number of frames: {ds_gt.sizes['time']}")
-print(f"Number of individuals: {ds_gt.sizes['individuals']}")
+print(f"Number of individuals: {ds_gt.sizes['individual']}")
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Read predictions as a movement dataset
@@ -49,7 +49,7 @@ print(ds_pred)
 # Print summary
 print(f"{ds_pred.source_file}")
 print(f"Number of frames: {ds_pred.sizes['time']}")
-print(f"Number of individuals: {ds_pred.sizes['individuals']}")
+print(f"Number of individuals: {ds_pred.sizes['individual']}")
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Check predicted and ground truth labels
@@ -79,14 +79,14 @@ fig.subplots_adjust(hspace=0.6, wspace=0.5)
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Compare lengths of trajectories
 non_nan_frames_gt = {}
-for ind, id_str in enumerate(ds_gt.individuals):
+for ind, id_str in enumerate(ds_gt.individual):
     non_nan_frames_gt[ind] = (
         len(ds_gt.time)
         - ds_gt.position[:, ind, :].isnull().any(axis=1).sum().item()
     )
 
 non_nan_frames_pred = {}
-for ind, id_str in enumerate(ds_pred.individuals):
+for ind, id_str in enumerate(ds_pred.individual):
     non_nan_frames_pred[ind] = (
         len(ds_pred.time)
         - ds_pred.position[:, ind, :].isnull().any(axis=1).sum().item()
@@ -110,7 +110,7 @@ out = ax.hist(
 ax.set_xlabel("n frames with same ID")
 ax.set_ylabel("n tracks")
 ax.tick_params(labeltop=False, labelright=True, right=True, which="both")
-ax.hlines(y=len(ds_gt.individuals), xmin=0, xmax=len(ds_gt.time), color="red")
+ax.hlines(y=len(ds_gt.individual), xmin=0, xmax=len(ds_gt.time), color="red")
 ax.legend(bbox_to_anchor=(1.0, 1.16))
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Check confidence of detections
@@ -146,7 +146,7 @@ for ds, title in zip(
     )
     color_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 
-    for ind_idx in range(ds.sizes["individuals"]):
+    for ind_idx in range(ds.sizes["individual"]):
         # plot trajectories
         ax.scatter(
             x=ds.position[:, ind_idx, 0],  # nframes, nindividuals, x
@@ -162,7 +162,7 @@ for ds, title in zip(
             ax.text(
                 x=ds.position[start_frame, ind_idx, 0],
                 y=ds.position[start_frame, ind_idx, 1],
-                s=ds.individuals[ind_idx].item(),
+                s=ds.individual[ind_idx].item(),
                 fontsize=8,
                 color=color_cycle[ind_idx % len(color_cycle)],
             )
@@ -194,7 +194,7 @@ title = "Prediction - color by confidence of detection"
 
 for vmin in [0.0, 0.8]:
     fig, ax = plt.subplots(1, 1)
-    for ind_idx in range(ds.sizes["individuals"]):
+    for ind_idx in range(ds.sizes["individual"]):
         im = ax.scatter(
             x=ds.position[:, ind_idx, 0],  # nframes, nindividuals, x
             y=ds.position[:, ind_idx, 1],

--- a/notebooks/notebook_overlay_video.py
+++ b/notebooks/notebook_overlay_video.py
@@ -29,7 +29,7 @@ print(ds_gt)
 # Print summary
 print(f"{ds_gt.source_file}")
 print(f"Number of frames: {ds_gt.sizes['time']}")
-print(f"Number of individuals: {ds_gt.sizes['individuals']}")
+print(f"Number of individuals: {ds_gt.sizes['individual']}")
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # # Read predictions as a movement dataset
@@ -46,7 +46,7 @@ print(ds_pred)
 # Print summary
 print(f"{ds_pred.source_file}")
 print(f"Number of frames: {ds_pred.sizes['time']}")
-print(f"Number of individuals: {ds_pred.sizes['individuals']}")
+print(f"Number of individuals: {ds_pred.sizes['individual']}")
 
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -80,7 +80,7 @@ def plot_trajectories(
 
     # plot all if not specified
     if list_individuals_idcs is None:
-        list_individuals_idcs = range(ds.sizes["individuals"])
+        list_individuals_idcs = range(ds.sizes["individual"])
 
     # plot trajectory per individual
     list_artists = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A toolkit for detecting and tracking crabs in the field."
 readme = "README.md"
-requires-python = ">=3.11.0"
+requires-python = ">=3.12.0"
 dynamic = ["version"]
 
 license = { text = "BSD-3-Clause" }
@@ -16,8 +16,8 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX",
     "License :: OSI Approved :: BSD License",
 ]
@@ -145,13 +145,13 @@ docstring-code-format = true # Also format code in docstrings
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{311,312}
+envlist = py{312,313}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 extras =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "mlflow",
     "optuna",
     "numpy>=2.0.0",
-    "movement",
+    "movement>=0.17.0", # dimensions renamed to singular (individual, keypoint)
     "dask",
     "numba>=0.60.0",
     # to avoid conflict between movement and sleap-nn;

--- a/tests/test_unit/test_create_zarr_dataset.py
+++ b/tests/test_unit/test_create_zarr_dataset.py
@@ -342,6 +342,6 @@ def test_create_final_zarr_store(
     ],
 )
 def test_renumber_individuals(width, expected_output):
-    ds = xr.Dataset(coords={"individuals": ["id_1", "id_3", "id_7"]})
+    ds = xr.Dataset(coords={"individual": ["id_1", "id_3", "id_7"]})
     result = _renumber_individuals(ds, width=width)
-    assert list(result.individuals.values) == expected_output
+    assert list(result.individual.values) == expected_output


### PR DESCRIPTION
## Description

**What is this PR?**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Two fixes + Python support upgrade

#### Fix 1: mlflow env var to use filesystem backend
The `crabs` package uses the filesystem backend to read and write to the MLflow database. The filesystem backend is now in maintenance mode, and the default and recommended approach is the database backend.

For now, we set `MLFLOW_ALLOW_FILE_STORE=true` to continue supporting the existing database, but this should be changed once the dataset of tracked models is updated.

#### Fix 2: movement singular dimensions
`movement` renamed its xarray dimension names from plural to singular, to follow pandas/xarray convention (a dimension names the individual element, not the collection):
- individuals → individual
- keypoints → keypoint

**Affected code**
Four spots in create_zarr_dataset.py reference the dimension:
* L44 — `DEFAULT_CHUNK_SIZES`
* L199, L201 — `_renumber_individuals` (ds.individuals, assign_coords(individuals=...))
* L319 — `max(len(ds.individuals) ...)`
* Plus the unit test `test_renumber_individuals` builds a dataset with an individuals coord and asserts on result.individuals.

The exploratory `notebooks/` also use `individuals` heavily, but they're not in the test path, so we define those as lower-priority cleanup.)

#### Python support upgrade
`movement` requires python >=3.12, so I upgraded the Python support too

**What does this PR do?**
* Sets the MLflow env var at `crabs/detector/__init__.py` so that we can use the filestore backend.
* Fixes so that tests pass with `movement>=0.17`
* Move Python support to "3.12", "3.13"

## References
Issue #287 and PR #285

## How has this PR been tested?

\

## Does this PR require an update to the documentation?

\
## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
